### PR TITLE
feat: agentic research redesign with planner, sharper agents, and display fix

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,21 @@
-f# Stock Portfolio Agent
+# Stock Portfolio Agent
+
+## ⚡ URGENT MISSION (Active Development Priority)
+
+**Re-design the entire agentic research flow.**
+
+Goals:
+- Rethink how specialized agents are orchestrated, what they research, and how results are synthesized
+- Evaluate replacing or augmenting the current RAG-lite chat with **NotebookLM integration** (Google NotebookLM API or export pipeline) for deeper, source-grounded Q&A on generated reports
+- Consider whether the current `ThreadPoolExecutor` parallel approach is the right model, or if a more dynamic agent-routing architecture fits better
+- Keep the Flask + MySQL foundation; redesign the AI layer on top of it
+
+Open questions to resolve during this work:
+1. How does NotebookLM integrate — direct API, PDF upload pipeline, or export + link?
+2. Should synthesis be a single agent or a multi-step critique/refine loop?
+3. What research subjects and data sources give the highest signal for stock analysis?
+
+---
 
 An AI-powered multi-agent stock research platform that orchestrates specialized research agents, integrates financial data APIs with real-time web research, and provides an interactive chat interface for exploring investment opportunities.
 

--- a/src/agent.py
+++ b/src/agent.py
@@ -17,6 +17,8 @@ from research_orchestrator import ResearchOrchestrator
 from synthesis_agent import SynthesisAgent
 from report_storage import ReportStorage
 from report_chat_agent import ReportChatAgent
+from planner_agent import PlannerAgent
+from research_plan import ResearchPlan
 
 # Load environment variables
 load_dotenv()
@@ -60,8 +62,10 @@ class StockResearchAgent:
         self.current_trade_type: Optional[str] = None
         self.current_report_id: Optional[str] = None
         self.last_report_text: Optional[str] = None
+        self.current_plan: Optional[ResearchPlan] = None
         self.research_orchestrator = ResearchOrchestrator(api_key=self.api_key)
         self.synthesis_agent = SynthesisAgent(api_key=self.api_key)
+        self.planner_agent = PlannerAgent(api_key=self.api_key)
         self.report_storage = ReportStorage()
         self.chat_agent = ReportChatAgent(api_key=self.api_key)
         
@@ -329,36 +333,52 @@ class StockResearchAgent:
         print(f"\n{'='*60}")
         print(f"Starting parallel research for {ticker} ({trade_type})")
         print(f"{'='*60}\n")
-        
+
         try:
-            # Step 1: Run parallel research
-            research_outputs = self.research_orchestrator.run_parallel_research(
+            # Step 1: Build research plan
+            print(f"{'='*60}")
+            print("Building research plan with PlannerAgent...")
+            print(f"{'='*60}\n")
+
+            plan = self.planner_agent.build_plan(
                 ticker=ticker,
                 trade_type=trade_type,
-                context=context,
+                conversation_context=context,
             )
-            
-            # Step 2: Synthesize report
+            self.current_plan = plan
+
+            print(
+                f"Research plan: {len(plan.selected_subject_ids)} subjects — "
+                + ", ".join(plan.selected_subject_ids)
+            )
+
+            # Step 2: Run parallel research
+            research_outputs = self.research_orchestrator.run_parallel_research(
+                plan=plan,
+            )
+
+            # Step 3: Synthesize report
             print(f"\n{'='*60}")
             print("Synthesizing research findings into final report...")
             print(f"{'='*60}\n")
-            
+
             report_text = self.synthesis_agent.synthesize_report(
                 ticker=ticker,
                 trade_type=trade_type,
                 research_outputs=research_outputs,
-                context=context,
+                plan=plan,
             )
-            
-            # Step 3: Store report with chunks and embeddings
+
+            # Step 4: Store report with chunks and embeddings
             print(f"\n{'='*60}")
             print("Storing report with chunking and embeddings...")
             print(f"{'='*60}\n")
-            
+
             metadata = {
                 "trade_type": trade_type,
-                "research_subjects": list(research_outputs.keys()),
-                "context": context,
+                "research_subjects": plan.selected_subject_ids,
+                "trade_context": plan.trade_context,
+                "planner_reasoning": plan.planner_reasoning,
             }
             
             report_id = self.report_storage.store_report(
@@ -405,6 +425,7 @@ class StockResearchAgent:
         self.current_ticker = None
         self.current_trade_type = None
         self.current_report_id = None
+        self.current_plan = None
         self.chat_agent.reset_conversation()
 
 

--- a/src/agent.py
+++ b/src/agent.py
@@ -6,6 +6,7 @@ import os
 import json
 import re
 import time
+import uuid
 from typing import Optional, Dict, Any, List, Any as AnyType
 from dotenv import load_dotenv
 
@@ -114,11 +115,11 @@ class StockResearchAgent:
                 # Generate report (this is synchronous but called from async function - OK)
                 report_text = self.generate_report(context=context_str)
                 report_id = self.current_report_id
-                
-                # Store report text for Flask session access
-                self.last_report_text = report_text
 
-                return f"Report generated successfully! Report ID: {report_id[:8] if report_id else 'N/A'}...\n\nThe comprehensive research report has been created. You can inform the user that the report is ready."
+                return (
+                    f"Report generated successfully! Report ID: {report_id[:8]}...\n\n"
+                    "The comprehensive research report has been created and is ready to view."
+                )
             except Exception as e:
                 return f"Error generating report: {str(e)}"
         
@@ -369,6 +370,10 @@ class StockResearchAgent:
                 plan=plan,
             )
 
+            # Set display-facing state immediately so the report renders even if storage fails
+            self.last_report_text = report_text
+            self.current_report_id = str(uuid.uuid4())  # temp ID — guarantees display works
+
             # Step 4: Store report with chunks and embeddings
             print(f"\n{'='*60}")
             print("Storing report with chunking and embeddings...")
@@ -380,20 +385,23 @@ class StockResearchAgent:
                 "trade_context": plan.trade_context,
                 "planner_reasoning": plan.planner_reasoning,
             }
-            
-            report_id = self.report_storage.store_report(
-                ticker=ticker,
-                trade_type=trade_type,
-                report_text=report_text,
-                metadata=metadata,
-            )
-            
-            self.current_report_id = report_id
-            
-            print(f"\n{'='*60}")
-            print(f"✓ Report generated and stored: {report_id}")
-            print(f"{'='*60}\n")
-            
+
+            try:
+                report_id = self.report_storage.store_report(
+                    ticker=ticker,
+                    trade_type=trade_type,
+                    report_text=report_text,
+                    metadata=metadata,
+                )
+                self.current_report_id = report_id  # overwrite temp ID with real DB ID
+                print(f"\n{'='*60}")
+                print(f"✓ Report generated and stored: {report_id}")
+                print(f"{'='*60}\n")
+            except Exception as storage_err:
+                print(
+                    f"⚠ Report storage failed (display will still work, RAG chat disabled): {storage_err}"
+                )
+
             return report_text
         
         except Exception as e:

--- a/src/conversation_handler_agent.py
+++ b/src/conversation_handler_agent.py
@@ -1,0 +1,173 @@
+"""
+Conversation handler agent for answering questions after report generation.
+Uses both the synthesized report (via RAG) and raw research outputs.
+"""
+
+import os
+from typing import List, Dict, Any, Optional
+from dotenv import load_dotenv
+
+from agents import Agent, Runner, trace, ModelSettings
+
+from embedding_service import EmbeddingService
+from vector_search import VectorSearch
+from report_storage import ReportStorage
+from research_prompt import get_conversation_handler_instructions
+
+load_dotenv()
+
+
+class ConversationHandlerAgent:
+    """Agent for handling post-report conversations using report and research outputs."""
+
+    def __init__(self, api_key: Optional[str] = None):
+        self.api_key = api_key or os.getenv("OPENAI_API_KEY")
+        if not self.api_key:
+            raise ValueError("OpenAI API key is required. Set OPENAI_API_KEY environment variable.")
+
+        self.embedding_service = EmbeddingService(api_key=self.api_key)
+        self.vector_search = VectorSearch()
+        self.report_storage = ReportStorage()
+        self.conversation_history: List[Dict[str, str]] = []
+
+    def answer_question(
+        self,
+        report_id: str,
+        user_question: str,
+        ticker: str,
+        trade_type: str,
+        conversation_history: Optional[List[Dict[str, str]]] = None,
+        top_k: int = 5
+    ) -> str:
+        """
+        Answer a question about a report using RAG retrieval and raw research outputs.
+
+        Args:
+            report_id: Report ID
+            user_question: User's question
+            ticker: Stock ticker symbol
+            trade_type: Type of trade
+            conversation_history: Previous conversation turns (optional)
+            top_k: Number of chunks to retrieve from report
+
+        Returns:
+            Agent's answer based on report excerpts and research outputs
+        """
+        query_embedding = self.embedding_service.create_embedding(user_question)
+
+        relevant_chunks = self.vector_search.search_chunks(
+            report_id=report_id,
+            query_embedding=query_embedding,
+            top_k=top_k
+        )
+
+        research_outputs = self.report_storage.get_research_outputs(report_id)
+
+        if not relevant_chunks and not research_outputs:
+            return "I couldn't find relevant information to answer your question. The report or research data may not be available."
+
+        prompt = self._build_prompt(
+            question=user_question,
+            report_chunks=relevant_chunks or [],
+            research_outputs=research_outputs or {},
+            conversation_history=conversation_history or self.conversation_history
+        )
+
+        system_instructions = get_conversation_handler_instructions(ticker, trade_type)
+
+        agent = Agent(
+            name="Conversation Handler Agent",
+            instructions=system_instructions,
+            model="gpt-4o",
+            tools=[],
+            model_settings=ModelSettings(temperature=0.7)
+        )
+
+        try:
+            with trace("Conversation Handler", metadata={
+                "report_id": report_id,
+                "chunks_retrieved": str(len(relevant_chunks)),
+                "research_outputs_count": str(len(research_outputs) if research_outputs else 0)
+            }):
+                result = Runner.run_sync(agent, prompt, max_turns=5)
+
+            if hasattr(result, 'final_output'):
+                return result.final_output
+            elif hasattr(result, 'output'):
+                return result.output
+            elif isinstance(result, str):
+                return result
+            return str(result)
+
+        except Exception as e:
+            error_msg = f"Error generating answer: {str(e)}"
+            print(error_msg)
+            return error_msg
+
+    def _build_prompt(
+        self,
+        question: str,
+        report_chunks: List[Dict[str, Any]],
+        research_outputs: Dict[str, Dict[str, Any]],
+        conversation_history: Optional[List[Dict[str, str]]] = None
+    ) -> str:
+        prompt_parts = []
+
+        if report_chunks:
+            prompt_parts.append("=== REPORT EXCERPTS ===\n")
+            for i, chunk in enumerate(report_chunks, 1):
+                section_info = f" (Section: {chunk.get('section', 'Unknown')})" if chunk.get('section') else ""
+                prompt_parts.append(f"[Report Excerpt {i}{section_info}]")
+                prompt_parts.append(chunk['chunk_text'])
+                prompt_parts.append("")
+
+        if research_outputs:
+            prompt_parts.append("=== RAW RESEARCH OUTPUTS ===\n")
+            prompt_parts.append(self._format_research_outputs(research_outputs))
+            prompt_parts.append("")
+
+        prompt_parts.append("---\n")
+
+        if conversation_history:
+            prompt_parts.append("Previous conversation:")
+            for turn in conversation_history[-3:]:
+                role = turn.get('role', 'user')
+                content = turn.get('content', '')
+                if role in ['user', 'assistant']:
+                    prompt_parts.append(f"{role.capitalize()}: {content}")
+            prompt_parts.append("")
+
+        prompt_parts.append(f"User question: {question}\n")
+        prompt_parts.append(
+            "Answer the question using ONLY the information from the report excerpts and raw research outputs above. "
+            "If the information is not available in these sources, say so clearly."
+        )
+
+        return "\n".join(prompt_parts)
+
+    def _format_research_outputs(self, research_outputs: Dict[str, Dict[str, Any]]) -> str:
+        formatted_parts = []
+
+        for subject_id, result in research_outputs.items():
+            subject_name = result.get('subject_name', subject_id)
+            research_output = result.get('research_output', '')
+
+            formatted_parts.append(f"[Research Subject: {subject_name} (ID: {subject_id})]")
+            formatted_parts.append(research_output)
+
+            sources = result.get('sources', [])
+            if sources:
+                formatted_parts.append("\nSources:")
+                for source in sources[:3]:
+                    if isinstance(source, dict):
+                        tool_name = source.get('tool', source.get('name', 'Unknown'))
+                        formatted_parts.append(f"  - {tool_name}")
+
+            formatted_parts.append("")
+            formatted_parts.append("---\n")
+
+        return "\n".join(formatted_parts)
+
+    def reset_conversation(self):
+        """Reset conversation history."""
+        self.conversation_history = []

--- a/src/mcp_client.py
+++ b/src/mcp_client.py
@@ -110,8 +110,16 @@ class MCPClient:
                 })
                 
                 if "result" in response and "tools" in response["result"]:
-                    self.tools_cache = response["result"]["tools"]
-                    return self.tools_cache
+                    returned_tools = response["result"]["tools"]
+                    # The server may only return meta-tools (TOOL_LIST, TOOL_GET, TOOL_CALL).
+                    # If so, fall through to the hardcoded fallback so agents get the real
+                    # Alpha Vantage tool definitions.
+                    _meta_tool_names = {"TOOL_LIST", "TOOL_GET", "TOOL_CALL"}
+                    actual_tools = [t for t in returned_tools if t.get("name", "") not in _meta_tool_names]
+                    if actual_tools:
+                        self.tools_cache = actual_tools
+                        return self.tools_cache
+                    # Only meta-tools returned — fall through to hardcoded fallback
             except Exception:
                 pass
             

--- a/src/planner_agent.py
+++ b/src/planner_agent.py
@@ -1,0 +1,220 @@
+"""
+PlannerAgent — selects and prioritises research subjects based on ticker,
+trade type, and the user's conversation context.
+
+Uses a single structured JSON call (no tool use) for speed and determinism.
+"""
+
+import json
+import os
+from typing import List
+
+from openai import OpenAI
+
+from research_plan import ResearchPlan
+from research_subjects import ResearchSubject, get_research_subjects_for_trade_type
+
+# Maximum subjects passed to the planner (caps the menu shown to the LLM).
+# Individual trade-type catalogs are small enough that this rarely fires,
+# but it prevents runaway costs if the catalog grows.
+PLANNER_MAX_SUBJECTS = int(os.getenv("PLANNER_MAX_SUBJECTS", "8"))
+
+
+class PlannerAgent:
+    """
+    Builds a ResearchPlan from ticker, trade type, and conversation context.
+
+    The plan specifies:
+    - which research subjects to run (ordered by priority)
+    - per-subject focus hints derived from the user's stated goals
+    - a distilled trade_context for the synthesis agent
+    """
+
+    def __init__(self, api_key: str = None):
+        self.api_key = api_key or os.getenv("OPENAI_API_KEY")
+        if not self.api_key:
+            raise ValueError(
+                "OpenAI API key is required. Set OPENAI_API_KEY environment variable."
+            )
+        self._client = OpenAI(api_key=self.api_key)
+
+    # ─── Public API ──────────────────────────────────────────────────────────
+
+    def build_plan(
+        self,
+        ticker: str,
+        trade_type: str,
+        conversation_context: str,
+    ) -> ResearchPlan:
+        """
+        Build a ResearchPlan for the given ticker/trade type/context.
+
+        Falls back to a safe default plan if the LLM call fails or returns
+        unparseable JSON.
+
+        Args:
+            ticker: Stock ticker symbol.
+            trade_type: One of "Day Trade", "Swing Trade", "Investment".
+            conversation_context: Raw user messages from the Q&A phase.
+
+        Returns:
+            ResearchPlan ready for the orchestrator.
+        """
+        eligible = get_research_subjects_for_trade_type(trade_type)
+        # Cap the catalog shown to the planner
+        eligible = eligible[:PLANNER_MAX_SUBJECTS]
+
+        system_prompt = self._build_system_prompt(ticker, trade_type, eligible)
+        user_prompt = self._build_user_prompt(
+            ticker, trade_type, conversation_context, eligible
+        )
+
+        try:
+            response = self._client.chat.completions.create(
+                model="gpt-4o",
+                temperature=0.3,
+                max_tokens=1200,
+                response_format={"type": "json_object"},
+                messages=[
+                    {"role": "system", "content": system_prompt},
+                    {"role": "user", "content": user_prompt},
+                ],
+            )
+            raw_json = response.choices[0].message.content
+            return self._parse_response(raw_json, ticker, trade_type, eligible)
+
+        except Exception as exc:
+            print(
+                f"[PlannerAgent] LLM call failed ({exc}); using full eligible subject list."
+            )
+            return self._fallback_plan(ticker, trade_type, eligible)
+
+    # ─── Prompt Builders ─────────────────────────────────────────────────────
+
+    def _build_system_prompt(
+        self,
+        ticker: str,
+        trade_type: str,
+        eligible: List[ResearchSubject],
+    ) -> str:
+        subject_lines = "\n".join(
+            f'  - "{s.id}": {s.name} — {s.description}' for s in eligible
+        )
+        return f"""You are a research planning assistant for a stock analysis platform.
+
+Your job is to select the most relevant research subjects for a {trade_type} analysis of {ticker},
+and to write per-subject focus hints that reflect what the user actually cares about.
+
+**Available subjects for {trade_type}:**
+{subject_lines}
+
+**Output a JSON object with exactly these keys:**
+{{
+  "selected_subject_ids": ["id1", "id2", ...],  // ordered by importance
+  "subject_focus": {{
+    "subject_id": "one-sentence focus hint referencing user's specific concern",
+    ...
+  }},
+  "trade_context": "2-3 sentence summary of user goals for the synthesis agent",
+  "reasoning": "your internal reasoning (logged only, never shown to user)"
+}}
+
+Rules:
+- Include ALL eligible subjects unless the user context makes one clearly irrelevant.
+- Order subjects by research importance for this specific situation.
+- Focus hints should be specific to user concerns; leave as "" when no particular focus applies.
+- trade_context is prose written for a synthesis agent, not bullet points.
+- reasoning is for logging only — be candid about your choices."""
+
+    def _build_user_prompt(
+        self,
+        ticker: str,
+        trade_type: str,
+        conversation_context: str,
+        eligible: List[ResearchSubject],
+    ) -> str:
+        context_section = (
+            f"**User conversation context:**\n{conversation_context}"
+            if conversation_context.strip()
+            else "**User conversation context:** (none provided)"
+        )
+        eligible_ids = [s.id for s in eligible]
+        return f"""Ticker: {ticker}
+Trade Type: {trade_type}
+Eligible subject IDs: {eligible_ids}
+
+{context_section}
+
+Build the research plan JSON now."""
+
+    # ─── Response Parser ─────────────────────────────────────────────────────
+
+    def _parse_response(
+        self,
+        raw_json: str,
+        ticker: str,
+        trade_type: str,
+        eligible: List[ResearchSubject],
+    ) -> ResearchPlan:
+        eligible_ids = {s.id for s in eligible}
+
+        try:
+            data = json.loads(raw_json)
+        except (json.JSONDecodeError, TypeError) as exc:
+            print(f"[PlannerAgent] JSON parse failed ({exc}); using fallback.")
+            return self._fallback_plan(ticker, trade_type, eligible)
+
+        # Validate and filter selected_subject_ids
+        raw_ids = data.get("selected_subject_ids", [])
+        if not isinstance(raw_ids, list):
+            raw_ids = []
+        # Keep only valid IDs, preserve order
+        selected_ids = [sid for sid in raw_ids if sid in eligible_ids]
+        # Append any eligible subject that was omitted (safety net)
+        present = set(selected_ids)
+        for s in eligible:
+            if s.id not in present:
+                selected_ids.append(s.id)
+
+        # Parse focus hints — default to "" for missing/invalid entries
+        raw_focus = data.get("subject_focus", {})
+        subject_focus = {}
+        if isinstance(raw_focus, dict):
+            for sid in selected_ids:
+                hint = raw_focus.get(sid, "")
+                subject_focus[sid] = hint if isinstance(hint, str) else ""
+
+        trade_context = data.get("trade_context", "")
+        if not isinstance(trade_context, str):
+            trade_context = ""
+
+        planner_reasoning = data.get("reasoning", "")
+        if not isinstance(planner_reasoning, str):
+            planner_reasoning = ""
+
+        return ResearchPlan(
+            ticker=ticker,
+            trade_type=trade_type,
+            selected_subject_ids=selected_ids,
+            subject_focus=subject_focus,
+            trade_context=trade_context,
+            planner_reasoning=planner_reasoning,
+        )
+
+    # ─── Fallback ────────────────────────────────────────────────────────────
+
+    def _fallback_plan(
+        self,
+        ticker: str,
+        trade_type: str,
+        eligible: List[ResearchSubject],
+    ) -> ResearchPlan:
+        """Return a safe plan using all eligible subjects and empty focus hints."""
+        return ResearchPlan(
+            ticker=ticker,
+            trade_type=trade_type,
+            selected_subject_ids=[s.id for s in eligible],
+            subject_focus={s.id: "" for s in eligible},
+            trade_context="",
+            planner_reasoning="fallback: LLM call failed or returned invalid JSON",
+        )

--- a/src/research_orchestrator.py
+++ b/src/research_orchestrator.py
@@ -3,148 +3,135 @@ Research orchestrator for coordinating parallel specialized research agents.
 """
 
 import os
-from typing import Dict, Any, List
+from typing import Dict, Any
 from concurrent.futures import ThreadPoolExecutor, as_completed
 import time
 
-from research_subjects import get_research_subjects, format_subject_prompt
+from research_plan import ResearchPlan
+from research_subjects import get_research_subject_by_id
 from specialized_agent import SpecializedResearchAgent
 
 # Default maximum worker count – controls how many specialized agents
-# run concurrently. This spreads token usage over time.
+# run concurrently.  Spreads token usage over time.
 DEFAULT_MAX_WORKERS = int(os.getenv("RESEARCH_MAX_WORKERS", "3"))
 
 
 class ResearchOrchestrator:
     """Orchestrates parallel research across multiple specialized agents."""
-    
+
     def __init__(self, api_key: str = None):
         """
         Initialize the research orchestrator.
-        
+
         Args:
             api_key: OpenAI API key (optional)
         """
         self.api_key = api_key
-    
-    def craft_research_prompts(
-        self,
-        ticker: str,
-        trade_type: str,
-        context: str = ""
-    ) -> Dict[str, str]:
-        """
-        Craft research prompts for all research subjects.
-        
-        Args:
-            ticker: Stock ticker symbol
-            trade_type: Type of trade
-            context: Additional context from followup questions
-        
-        Returns:
-            Dictionary mapping subject_id -> formatted prompt
-        """
-        subjects = get_research_subjects()
-        prompts = {}
-        
-        for subject in subjects:
-            prompt = format_subject_prompt(subject, ticker, trade_type, context)
-            prompts[subject.id] = prompt
-        
-        return prompts
-    
+
     def run_parallel_research(
         self,
-        ticker: str,
-        trade_type: str,
-        context: str = "",
+        plan: ResearchPlan,
         max_workers: int = DEFAULT_MAX_WORKERS,
     ) -> Dict[str, Dict[str, Any]]:
         """
-        Execute parallel research using specialized agents.
-        
+        Execute parallel research using specialized agents driven by a ResearchPlan.
+
+        Subjects are submitted to the thread pool in priority order
+        (plan.selected_subject_ids is already sorted).
+
         Args:
-            ticker: Stock ticker symbol
-            trade_type: Type of trade
-            context: Additional context from followup questions
-            max_workers: Maximum number of parallel workers (default: 6)
-        
+            plan: ResearchPlan from PlannerAgent
+            max_workers: Maximum number of parallel workers
+
         Returns:
-            Dictionary mapping subject_id -> research results
+            Dictionary mapping subject_id → research result dict
         """
-        subjects = get_research_subjects()
-        results = {}
-        
+        ticker = plan.ticker
+        trade_type = plan.trade_type
+        subject_ids = plan.selected_subject_ids
+
         print(f"Starting parallel research for {ticker} ({trade_type})...")
         print(
-            f"Researching {len(subjects)} subjects with up to "
+            f"Researching {len(subject_ids)} subjects with up to "
             f"{max_workers} concurrent workers..."
         )
-        
+
         start_time = time.time()
-        
-        # Use ThreadPoolExecutor for parallel execution
+        results: Dict[str, Dict[str, Any]] = {}
+
         with ThreadPoolExecutor(max_workers=max_workers) as executor:
-            # Submit all research tasks
-            future_to_subject = {}
-            
-            for subject in subjects:
+            future_to_id: Dict[Any, str] = {}
+
+            # Submit futures in priority order so the thread pool schedules
+            # higher-priority work first.
+            for subject_id in subject_ids:
+                try:
+                    subject = get_research_subject_by_id(subject_id)
+                except ValueError as exc:
+                    print(f"⚠  Skipping unknown subject id '{subject_id}': {exc}")
+                    continue
+
+                focus_hint = plan.subject_focus.get(subject_id, "")
                 agent = SpecializedResearchAgent(api_key=self.api_key)
                 future = executor.submit(
                     agent.research_subject,
                     ticker,
                     subject,
                     trade_type,
-                    context
+                    focus_hint,
                 )
-                future_to_subject[future] = subject
-            
+                future_to_id[future] = subject_id
+
             # Collect results as they complete
             completed = 0
-            for future in as_completed(future_to_subject):
-                subject = future_to_subject[future]
+            total = len(future_to_id)
+            for future in as_completed(future_to_id):
+                subject_id = future_to_id[future]
                 try:
                     result = future.result()
-                    results[subject.id] = result
+                    results[subject_id] = result
                     completed += 1
-                    print(f"✓ Completed research for: {subject.name} ({completed}/{len(subjects)})")
+                    print(
+                        f"✓ Completed research for: {result.get('subject_name', subject_id)} "
+                        f"({completed}/{total})"
+                    )
                 except Exception as e:
-                    print(f"✗ Error researching {subject.name}: {e}")
-                    results[subject.id] = {
-                        "subject_id": subject.id,
-                        "subject_name": subject.name,
+                    print(f"✗ Error researching {subject_id}: {e}")
+                    results[subject_id] = {
+                        "subject_id": subject_id,
+                        "subject_name": subject_id,
                         "research_output": f"Error: {str(e)}",
                         "sources": [],
                         "ticker": ticker,
                         "trade_type": trade_type,
-                        "error": str(e)
+                        "focus_hint": plan.subject_focus.get(subject_id, ""),
+                        "error": str(e),
                     }
                     completed += 1
-        
-        elapsed_time = time.time() - start_time
-        print(f"✓ Parallel research completed in {elapsed_time:.2f} seconds")
-        
+
+        elapsed = time.time() - start_time
+        print(f"✓ Parallel research completed in {elapsed:.2f} seconds")
+
         return results
-    
+
     def get_research_summary(self, results: Dict[str, Dict[str, Any]]) -> str:
         """
         Generate a summary of research results.
-        
+
         Args:
             results: Dictionary of research results from parallel execution
-        
+
         Returns:
             Summary string
         """
         summary_lines = ["Research Summary:"]
         summary_lines.append(f"Total subjects researched: {len(results)}")
-        
+
         successful = sum(1 for r in results.values() if "error" not in r)
         summary_lines.append(f"Successful: {successful}/{len(results)}")
-        
+
         if successful < len(results):
             failed = [r["subject_name"] for r in results.values() if "error" in r]
             summary_lines.append(f"Failed subjects: {', '.join(failed)}")
-        
-        return "\n".join(summary_lines)
 
+        return "\n".join(summary_lines)

--- a/src/research_plan.py
+++ b/src/research_plan.py
@@ -1,0 +1,34 @@
+"""
+ResearchPlan dataclass — output of PlannerAgent, input to ResearchOrchestrator and SynthesisAgent.
+"""
+
+from dataclasses import dataclass, field
+from typing import Dict, List
+
+
+@dataclass
+class ResearchPlan:
+    """
+    Encapsulates everything the orchestrator and synthesis agent need to run
+    a targeted, user-aware research session.
+
+    Attributes:
+        ticker: Stock ticker symbol (e.g. "AAPL").
+        trade_type: One of "Day Trade", "Swing Trade", "Investment".
+        selected_subject_ids: Ordered list of research subject IDs to run,
+            sorted by priority (highest first).
+        subject_focus: Mapping of subject_id → a one-paragraph focus hint
+            derived from the user's stated concerns.  Empty string when no
+            specific focus applies.
+        trade_context: A concise summary of the user's goals / context,
+            passed to the synthesis agent so it can frame the narrative.
+        planner_reasoning: Internal reasoning from the planner LLM — logged
+            to DB metadata but never injected into downstream prompts.
+    """
+
+    ticker: str
+    trade_type: str
+    selected_subject_ids: List[str] = field(default_factory=list)
+    subject_focus: Dict[str, str] = field(default_factory=dict)
+    trade_context: str = ""
+    planner_reasoning: str = ""

--- a/src/research_prompt.py
+++ b/src/research_prompt.py
@@ -86,7 +86,7 @@ def get_specialized_agent_instructions(subject_id: str, ticker: str, trade_type:
     Returns:
         System instructions string for the specialized agent
     """
-    from src.research_subjects import get_research_subject_by_id, format_subject_prompt
+    from src.research_subjects import get_research_subject_by_id
     
     subject = get_research_subject_by_id(subject_id)
     
@@ -111,15 +111,17 @@ Your specific research task: {subject.description}
 - Alpha Vantage MCP: structured financial data, fundamentals, statements.
 - Perplexity Research: real-time news, analysis, qualitative insights.
 
-**Output Requirements:**
-1. Provide clear research findings on {subject.name}.
-2. Include only the most relevant metrics and facts.
-3. Cite sources (tool outputs, research results) as needed.
-4. Structure your response with:
-   - Key findings
-   - Supporting data
-   - Sources/citations
-   - Brief analysis and context
+**Output Format (required):**
+- Use markdown headers for each analytical section
+- Lead every section with a 1-sentence "bottom line" finding, then support with data
+- Quantify every claim — avoid vague language ("growing well" → "revenue +23% YoY")
+- Flag any data gaps or conflicting signals explicitly
+- End with a **Key Takeaways** section: 3–5 bullets, each containing a specific metric or fact
+
+**Scope constraint:**
+- Focus exclusively on {subject.name}
+- Do not duplicate findings that belong to other research subjects
+- Cite the specific tool or source for each data point
 
 Begin your research now."""
     

--- a/src/research_subjects.py
+++ b/src/research_subjects.py
@@ -3,7 +3,7 @@ Research subject definitions for specialized agent research.
 """
 
 from typing import Dict, List
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 
 @dataclass
@@ -13,168 +13,447 @@ class ResearchSubject:
     name: str
     description: str
     prompt_template: str
+    trade_types: List[str] = field(default_factory=list)   # eligible trade types
+    priority: Dict[str, int] = field(default_factory=dict)  # trade_type → 1=high, 2=medium, 3=low
 
 
-# Research subject definitions
-PRODUCTS_SERVICES = ResearchSubject(
-    id="products_services",
-    name="Products and Services",
-    description="What products/services does the business offer?",
-    prompt_template="""Research and provide comprehensive information about {ticker}'s products and services.
+# ─── Subject Definitions ─────────────────────────────────────────────────────
 
-Focus on:
-- Complete product/service portfolio
-- Product categories and lines
-- Service offerings
-- Key features and capabilities
-- Product lifecycle stages
-- Innovation and R&D focus areas
+COMPANY_OVERVIEW = ResearchSubject(
+    id="company_overview",
+    name="Company Overview",
+    description="Business model, sector, recent corporate developments, and market position",
+    prompt_template="""Research and provide a structured company overview for {ticker}.
 
-Use Alpha Vantage MCP tools for company overview and financial data, and Perplexity research for detailed product information, market positioning, and recent product launches or updates."""
+**Business model:**
+- How does the company make money? (revenue model: subscription, transactional, licensing, services)
+- Who are the customers? (SMB, enterprise, consumer, government — and typical contract size)
+- What is the core value proposition in one sentence?
+
+**Economic engine:**
+- Primary revenue driver (volume, price, or mix)
+- Gross margin profile and what drives it
+- Reinvestment model: does the company grow by adding capacity, people, or technology?
+
+**Corporate structure:**
+- Key business segments and their relative size
+- Recent M&A, divestitures, or strategic pivots (last 18 months)
+- Any upcoming strategic decisions (CEO transition, spin-off, etc.)
+
+**Market position:**
+- Market share estimate and rank in primary market
+- TAM estimate and penetration rate
+
+Use Alpha Vantage overview tool for fundamentals. Use Perplexity for recent corporate developments and market positioning.
+Quantify every claim. No valuation multiples.""",
+    trade_types=["Day Trade", "Swing Trade", "Investment"],
+    priority={"Day Trade": 1, "Swing Trade": 1, "Investment": 1},
+)
+
+NEWS_CATALYSTS = ResearchSubject(
+    id="news_catalysts",
+    name="News & Catalysts",
+    description="Recent news, upcoming events, and near-term catalysts that could move the stock",
+    prompt_template="""Research recent news and near-term catalysts for {ticker}.
+
+For each catalyst, provide: **Event | Date/Timeline | Bull case impact | Bear case impact | Probability assessment**
+
+**Near-term catalysts (0–30 days):**
+- Earnings date and key metrics to watch (revenue, margins, guidance)
+- Product launches or conference presentations
+- Regulatory decisions pending
+
+**Medium-term catalysts (1–3 months):**
+- Analyst day, investor day, or capital markets day
+- Contract wins, partnership announcements
+- Macro events affecting the sector
+
+**Sentiment data:**
+- News sentiment trend (bullish / neutral / bearish) from last 30 days
+- Analyst rating changes and price target revisions (last 60 days)
+- Insider buying or selling (last 90 days) — net buyer or seller?
+
+**Risks to the catalyst thesis:**
+- What would make each catalyst disappoint?
+- Any events that could be negative surprises?
+
+Use Alpha Vantage news sentiment tool. Use Perplexity for real-time event calendar and analyst activity.
+Quantify every claim.""",
+    trade_types=["Day Trade", "Swing Trade", "Investment"],
+    priority={"Day Trade": 1, "Swing Trade": 1, "Investment": 2},
+)
+
+TECHNICAL_PRICE_ACTION = ResearchSubject(
+    id="technical_price_action",
+    name="Technical / Price Action",
+    description="Price trends, key support/resistance, volume, and momentum indicators",
+    prompt_template="""Research technical price action and momentum for {ticker}.
+
+**Price structure:**
+- Trend: above/below 20, 50, 200 DMA? (state exact values if available)
+- Key support levels (last 2–3 significant lows with price levels)
+- Key resistance levels (last 2–3 significant highs with price levels)
+- Distance from 52-week high and low (% from each)
+
+**Volume analysis:**
+- Average daily volume (20-day) vs. recent sessions
+- Unusual volume spikes: date, direction, follow-through
+- Accumulation vs. distribution pattern (up days vs. down days by volume)
+
+**Momentum:**
+- Relative strength vs. S&P 500 (last 30 days, quantify the delta)
+- Relative strength vs. sector ETF
+- Short interest: % float, days-to-cover, recent change direction
+
+**Actionable context for trade type:**
+- Day Trade: intraday range, pre-market catalyst, key levels for entry/stop
+- Swing Trade: breakout/breakdown levels, catalyst timeline, risk/reward setup
+
+Use Alpha Vantage price data. Use Perplexity for technical analysis commentary and short interest data.
+State all price levels explicitly.""",
+    trade_types=["Day Trade", "Swing Trade"],
+    priority={"Day Trade": 1, "Swing Trade": 2},
+)
+
+EARNINGS_FINANCIALS = ResearchSubject(
+    id="earnings_financials",
+    name="Earnings & Financials",
+    description="Recent earnings results, guidance, and key financial statement metrics",
+    prompt_template="""Research earnings quality and financial health for {ticker}.
+
+**Earnings quality:**
+- Last 4–6 quarters: revenue, gross profit, operating income, EPS — actual vs. consensus
+- Beat/miss cadence: consistent beater, in-liner, or miss pattern?
+- Quality of beat: was it revenue-driven or cost-cuts / tax / buybacks?
+
+**Guidance credibility:**
+- Compare last 4 quarters of initial guidance vs. actual results
+- Is management conservative, accurate, or aspirational in guidance?
+- Current quarter and full-year guidance vs. consensus
+
+**Cash flow quality:**
+- FCF vs. net income gap (working capital dynamics, stock-based comp)
+- CapEx intensity trend and maintenance vs. growth CapEx split
+- Cash conversion cycle trend
+
+**Balance sheet health:**
+- Net debt / EBITDA and trend
+- Current ratio, quick ratio
+- Any covenant risks or refinancing needs in next 18 months
+
+Use Alpha Vantage income statement, earnings, cash flow, and balance sheet tools.
+Quantify every claim. Show trends, not snapshots.""",
+    trade_types=["Swing Trade", "Investment"],
+    priority={"Swing Trade": 1, "Investment": 1},
+)
+
+SECTOR_MACRO = ResearchSubject(
+    id="sector_macro",
+    name="Sector & Macro Context",
+    description="Industry trends, macro tailwinds/headwinds, and sector rotation dynamics",
+    prompt_template="""Research sector and macro context relevant to {ticker}.
+
+**Sector context:**
+- Sector ETF performance last 30/90 days vs. S&P 500 (quantify the delta)
+- Where are we in the sector cycle? (early, mid, late expansion / contraction)
+- Key macro variables driving the sector (rates, consumer spending, enterprise budgets, commodities)
+
+**Sensitivity mapping:**
+- If [key macro variable] moves X%, what is the historical revenue/margin impact for this sector?
+- What is the beta of the sector ETF to the broader market?
+
+**Rotation dynamics:**
+- Is money flowing into or out of this sector? (fund flows, RSI of sector ETF)
+- Is this a defensive or cyclical sector? Current market preference?
+
+**Peer sector performance:**
+- Name 2–3 sector peers, their YTD performance, and any recent divergence from the subject company
+
+Use Perplexity for sector analysis and macro commentary.
+Quantify all sensitivities and performance figures where possible.""",
+    trade_types=["Day Trade", "Swing Trade"],
+    priority={"Day Trade": 2, "Swing Trade": 2},
 )
 
 REVENUE_BREAKDOWN = ResearchSubject(
     id="revenue_breakdown",
     name="Revenue Breakdown",
-    description="Revenue breakdown by product, geography, and channel",
-    prompt_template="""Research and provide detailed revenue breakdown for {ticker}.
+    description="Revenue by segment, geography, and channel with growth trends",
+    prompt_template="""Research and provide detailed revenue decomposition for {ticker}.
 
-Focus on:
-- Revenue by product/service line
-- Revenue by geographic region
-- Revenue by sales channel (direct, indirect, online, retail, etc.)
-- Revenue trends and growth rates by segment
-- Percentage contribution of each segment
-- Historical revenue mix changes
+**Decompose revenue into: Segment × Geography × Channel × Customer type**
 
-Use Alpha Vantage MCP tools for financial statements and income statements. Use Perplexity research for detailed segment reporting, geographic revenue data, and channel-specific information from company reports and filings."""
+For each dimension:
+- % contribution to total revenue
+- YoY growth rate
+- Margin profile if disclosed (higher-margin mix shift = positive signal)
+
+**Attribution:**
+- How much of YoY revenue growth came from: volume, price, mix, new products, M&A?
+- Is mix shifting toward higher- or lower-margin segments?
+
+**Recurring vs. non-recurring:**
+- Subscription / recurring revenue as % of total
+- Transactional / one-time revenue trends
+- Renewal rates or re-order rates if disclosed
+
+**Key concentration risks:**
+- Top 3 customers as % of revenue
+- Top 3 geographies as % of revenue
+
+Use Alpha Vantage income statement tools. Use Perplexity for detailed segment reporting from 10-K/10-Q filings.
+Quantify every claim. Show 2–4 quarter trend for each major segment.""",
+    trade_types=["Swing Trade", "Investment"],
+    priority={"Swing Trade": 2, "Investment": 1},
 )
 
-VALUE_PROPOSITIONS = ResearchSubject(
-    id="value_propositions",
-    name="Value Propositions and Key Clients",
-    description="Value propositions and key clients",
-    prompt_template="""Research {ticker}'s value propositions and key clients.
+GROWTH_DRIVERS = ResearchSubject(
+    id="growth_drivers",
+    name="Growth Drivers",
+    description="Key organic and inorganic growth drivers over the next 1-3 years",
+    prompt_template="""Research the primary growth drivers for {ticker} using a decomposition framework.
 
-Focus on:
-- Core value propositions for each product/service
-- Unique selling points and competitive advantages
-- Key customer segments
-- Major clients and customer relationships
-- Customer retention and loyalty metrics
-- Market positioning and brand value
+**Growth = Volume × Price × Mix × New Products × Geography**
 
-Use Alpha Vantage MCP tools for company overview. Use Perplexity research for customer case studies, client lists, value proposition details, and market positioning information."""
+For each lever:
+- What is the current contribution? (quantify if disclosed)
+- What is the trajectory (accelerating / decelerating / inflecting)?
+- What management actions or external factors drive it?
+
+**TAM and market penetration:**
+- TAM estimate and current penetration rate
+- Customer count, cohort retention, and expansion revenue trends
+- Product pipeline with expected revenue contribution
+- Geographic white space and go-to-market model
+
+**Sector-specific KPIs (use whichever apply):**
+- SaaS: NRR, GRR, logo retention, seats/ARR per account
+- Payments: TPV growth, take rate trend, new verticals
+- Consumer: same-store sales, basket size, traffic vs. conversion
+- Industrial: volume/price/mix split from earnings calls
+
+Use filings and earnings transcripts. Show mechanisms, not conclusions.
+No valuation multiples. Quantify every claim.""",
+    trade_types=["Swing Trade", "Investment"],
+    priority={"Swing Trade": 2, "Investment": 1},
 )
 
-BUYING_PROCESS = ResearchSubject(
-    id="buying_process",
-    name="Buying Process",
-    description="Who buys and how does the buying process work?",
-    prompt_template="""Research {ticker}'s customer buying process and decision-makers.
+VALUATION = ResearchSubject(
+    id="valuation",
+    name="Valuation & Peers",
+    description="Current valuation multiples vs. peers and historical ranges",
+    prompt_template="""Research the valuation and peer comparison for {ticker}.
 
-Focus on:
-- Primary customer types and personas
-- Decision-making process and stakeholders
-- Sales cycle length and stages
-- Buying criteria and evaluation factors
-- Procurement processes
-- Customer acquisition channels
-- Relationship management approach
+**Current multiples:**
+- P/E, P/S, EV/Revenue, EV/EBITDA, P/FCF — current vs. 1-year and 3-year historical average
+- NTM vs. LTM multiples to show forward-looking premium/discount
 
-Use Perplexity research for detailed information about customer buying behavior, sales processes, and industry-specific procurement patterns."""
-)
+**Peer table (3–5 direct comps):**
+| Peer | P/S | EV/EBITDA | Rev Growth | Gross Margin | Premium/Discount to subject |
 
-SEASONALITY = ResearchSubject(
-    id="seasonality",
-    name="Seasonality",
-    description="Seasonality patterns",
-    prompt_template="""Research seasonal patterns and cyclicality for {ticker}.
+**Valuation rationale:**
+- Is the premium/discount justified by growth rate, margin profile, or moat quality?
+- At what growth rate does the current multiple imply fair value?
 
-Focus on:
-- Quarterly revenue patterns
-- Seasonal demand fluctuations
-- Industry-specific seasonality
-- Historical seasonal trends
-- Peak and off-peak periods
-- Factors driving seasonality
-- Impact of seasonality on operations and cash flow
+**Analyst consensus:**
+- Price target range (low / consensus / high)
+- Bull/base/bear scenarios with key assumptions
 
-Use Alpha Vantage MCP tools for quarterly earnings and financial data. Use Perplexity research for industry-specific seasonal patterns and analysis."""
+Do not provide a buy/sell recommendation — present the data and implied math.
+Use Alpha Vantage financial data. Use Perplexity for peer multiples and analyst targets.""",
+    trade_types=["Investment"],
+    priority={"Investment": 1},
 )
 
 MARGIN_STRUCTURE = ResearchSubject(
     id="margin_structure",
     name="Margin Structure",
-    description="Margin structure by segment",
-    prompt_template="""Research {ticker}'s margin structure by business segment.
+    description="Gross, operating, and net margin trends with segment-level profitability",
+    prompt_template="""Research {ticker}'s margin structure using a margin tree framework.
 
-Focus on:
-- Gross margins by product/service line
-- Operating margins by segment
-- Profitability by geography
-- Margin trends over time
-- Factors affecting margins
-- Cost structure by segment
-- Margin improvement initiatives
+**Margin Tree: Gross → Operating → EBITDA → Free Cash Flow**
+For each layer: show the lever (what moves it), the trend (last 6–8 quarters), and the sensitivity.
 
-Use Alpha Vantage MCP tools for income statements and financial data. Use Perplexity research for detailed segment margin analysis and cost structure information."""
+**Unit economics:**
+- Revenue per unit / ASP, COGS per unit, gross margin per unit
+- Variable vs. fixed cost split (operating leverage ratio)
+- For SaaS: CAC, payback period, LTV/CAC, churn-adjusted payback
+- For retail/consumer: contribution margin per transaction
+
+**Sensitivity analysis:**
+- If gross margin moves ±100bps, what is the operating margin impact?
+- If volume falls 10%, what is the FCF impact (given fixed cost base)?
+
+**Operating leverage:**
+- At what revenue level does the company hit positive FCF / operating leverage inflection?
+- What % of OpEx is fixed vs. variable?
+
+**Sector-specific (use whichever apply):**
+- SaaS: S&M as % of new ARR, R&D as % of revenue vs. peers
+- Payments: processing cost as % of TPV, interchange economics
+- Industrial: capacity utilization rate, breakeven volume
+
+Use Alpha Vantage income statement and cash flow tools.
+No valuation multiples. Quantify every claim.""",
+    trade_types=["Swing Trade", "Investment"],
+    priority={"Swing Trade": 3, "Investment": 2},
+)
+
+COMPETITIVE_POSITION = ResearchSubject(
+    id="competitive_position",
+    name="Competitive Position",
+    description="Competitive moat, market share, and positioning vs. key rivals",
+    prompt_template="""Research {ticker}'s competitive position using a structured moat framework.
+
+**Moat inventory — for each moat type, state whether it exists and cite evidence:**
+1. Switching costs: what does it cost a customer to leave? (time, data migration, retraining)
+2. Network effects: does the product get more valuable with more users?
+3. Cost advantage: scale economics, proprietary supply, or process advantages
+4. Intangibles: patents, licenses, brand (pricing power evidence)
+5. Efficient scale: natural monopoly or oligopoly dynamics
+
+**Competitive dynamics:**
+- Top 3 competitors: name, their moat, market share estimate, key differentiator
+- Win/loss dynamics: where is the company winning and losing deals, and why?
+- Pricing power: has ASP / take rate held, expanded, or eroded over 3 years?
+- New entrant risk: barriers to entry and any credible threats
+
+**Customer evidence:**
+- NPS or satisfaction scores if public
+- Churn rate trend (quantify)
+- Case studies or public customer testimonials showing stickiness
+
+No valuation multiples. Focus on structural advantages and durability.
+Use Alpha Vantage overview tool. Use Perplexity for competitive landscape analysis and market share data.""",
+    trade_types=["Investment"],
+    priority={"Investment": 1},
+)
+
+RISK_FACTORS = ResearchSubject(
+    id="risk_factors",
+    name="Risk Factors",
+    description="Key risks: operational, financial, regulatory, and macro",
+    prompt_template="""Research the key risk factors for {ticker}.
+
+**For each risk, provide: Description | Probability (H/M/L) | Revenue impact if realized | Mitigants**
+
+**Tier 1 — Existential / high-impact:**
+- Regulatory or legal risk (active litigation, pending regulation)
+- Customer concentration (lose top customer = X% revenue loss)
+- Technology disruption risk
+
+**Tier 2 — Operational:**
+- Execution risk on key growth initiative
+- Supply chain or input cost exposure
+- Key-person dependency
+
+**Tier 3 — Financial:**
+- Leverage and refinancing risk
+- FCF breakeven timeline if growth slows
+- Dilution risk (equity raises, SBC trajectory)
+
+**Macro sensitivities:**
+- Revenue sensitivity to: interest rates, FX, consumer spending, enterprise IT budgets
+- Quantify where disclosed (e.g., "10% USD strengthening → 3% revenue headwind")
+
+Source: 10-K risk factors, recent earnings call commentary, analyst notes.
+Use Alpha Vantage financials for financial risk indicators. Use Perplexity for regulatory and governance risk.""",
+    trade_types=["Swing Trade", "Investment"],
+    priority={"Swing Trade": 3, "Investment": 2},
+)
+
+MANAGEMENT_QUALITY = ResearchSubject(
+    id="management_quality",
+    name="Management Quality",
+    description="Leadership track record, capital allocation discipline, and insider alignment",
+    prompt_template="""Research {ticker}'s management team quality and capital allocation track record.
+
+**Track record (last 3–5 years):**
+- Revenue and EPS CAGR vs. initial guidance (how accurate was management?)
+- Margins: promised vs. delivered
+- Capital allocation: buybacks (EPS accretive?), M&A (value-creating?), dividends vs. reinvestment
+
+**Capital allocation scorecard:**
+- ROIC trend (is the company earning above its cost of capital?)
+- FCF conversion rate (% of net income converted to FCF)
+- SBC as % of revenue (dilution burden)
+- M&A track record: acquisitions announced, integration outcomes, multiple paid vs. current trading multiple of target
+
+**Alignment:**
+- CEO/CFO tenure and prior track record
+- Insider ownership %: executive team, board
+- Insider transactions last 12 months: net buyer or seller?
+- Compensation structure: short-term vs. long-term, metrics tied to comp
+
+**Governance flags:**
+- Any restatements, SEC inquiries, or material weaknesses
+- Board independence %
+
+Use Alpha Vantage financials for ROIC and FCF data. Use Perplexity for proxy filings, insider data, and governance analysis.
+Quantify every claim.""",
+    trade_types=["Investment"],
+    priority={"Investment": 2},
 )
 
 
-def get_research_subjects() -> List[ResearchSubject]:
+# ─── Master List ─────────────────────────────────────────────────────────────
+
+ALL_SUBJECTS: List[ResearchSubject] = [
+    COMPANY_OVERVIEW,
+    NEWS_CATALYSTS,
+    TECHNICAL_PRICE_ACTION,
+    EARNINGS_FINANCIALS,
+    SECTOR_MACRO,
+    REVENUE_BREAKDOWN,
+    GROWTH_DRIVERS,
+    VALUATION,
+    MARGIN_STRUCTURE,
+    COMPETITIVE_POSITION,
+    RISK_FACTORS,
+    MANAGEMENT_QUALITY,
+]
+
+_SUBJECT_MAP: Dict[str, ResearchSubject] = {s.id: s for s in ALL_SUBJECTS}
+
+
+# ─── Public API ──────────────────────────────────────────────────────────────
+
+def get_research_subjects_for_trade_type(trade_type: str) -> List[ResearchSubject]:
     """
-    Get all research subjects.
-    
+    Return subjects eligible for the given trade type, sorted by priority (ascending).
+
+    Args:
+        trade_type: One of "Day Trade", "Swing Trade", "Investment"
+
     Returns:
-        List of ResearchSubject objects
+        Priority-sorted list of ResearchSubject objects
     """
-    return [
-        PRODUCTS_SERVICES,
-        REVENUE_BREAKDOWN,
-        VALUE_PROPOSITIONS,
-        BUYING_PROCESS,
-        SEASONALITY,
-        MARGIN_STRUCTURE
-    ]
+    eligible = [s for s in ALL_SUBJECTS if trade_type in s.trade_types]
+    return sorted(eligible, key=lambda s: s.priority.get(trade_type, 99))
 
 
 def get_research_subject_by_id(subject_id: str) -> ResearchSubject:
     """
     Get a research subject by ID.
-    
+
     Args:
-        subject_id: Subject ID
-    
+        subject_id: Subject ID string
+
     Returns:
         ResearchSubject object
-    
+
     Raises:
         ValueError: If subject ID not found
     """
-    for subject in get_research_subjects():
-        if subject.id == subject_id:
-            return subject
-    raise ValueError(f"Research subject not found: {subject_id}")
+    subject = _SUBJECT_MAP.get(subject_id)
+    if subject is None:
+        raise ValueError(f"Research subject not found: {subject_id}")
+    return subject
 
 
-def format_subject_prompt(subject: ResearchSubject, ticker: str, trade_type: str, context: str = "") -> str:
+def get_research_subjects() -> List[ResearchSubject]:
     """
-    Format a research subject prompt with ticker and context.
-    
-    Args:
-        subject: ResearchSubject object
-        ticker: Stock ticker symbol
-        trade_type: Type of trade
-        context: Additional context from followup questions
-    
-    Returns:
-        Formatted prompt string
+    Deprecated alias — returns Investment-level subjects for backwards compatibility.
+    Prefer get_research_subjects_for_trade_type() for new code.
     """
-    base_prompt = subject.prompt_template.format(ticker=ticker)
-    
-    if context:
-        base_prompt += f"\n\nAdditional context from user: {context}"
-    
-    return base_prompt
-
+    return get_research_subjects_for_trade_type("Investment")

--- a/src/specialized_agent.py
+++ b/src/specialized_agent.py
@@ -84,24 +84,35 @@ class SpecializedResearchAgent:
         self,
         subject: ResearchSubject,
         ticker: str,
-        trade_type: str
+        trade_type: str,
+        focus_hint: str = "",
     ) -> str:
         """
         Generate specialized system instructions for a research subject.
-        
+
         Args:
             subject: ResearchSubject object
             ticker: Stock ticker symbol
             trade_type: Type of trade
-        
+            focus_hint: Optional per-subject focus hint from PlannerAgent
+
         Returns:
             System instructions string
         """
         from src.date_utils import get_datetime_context_string
-        
+
         # Get current date/time context
         datetime_context = get_datetime_context_string()
-        
+
+        # Build optional focus block
+        focus_block = ""
+        if focus_hint:
+            focus_block = f"""
+**Specific Research Focus (from user context):**
+{focus_hint}
+Prioritize this focus while still covering the full subject area.
+"""
+
         instructions = f"""You are a specialized research analyst focusing on {subject.name} for {ticker}.
 
 {datetime_context}
@@ -110,7 +121,7 @@ Your specific research task: {subject.description}
 
 **Research Objective:**
 {subject.prompt_template.format(ticker=ticker)}
-
+{focus_block}
 **Trade Type Context:** {trade_type}
 - Adjust your research depth and focus based on this trade type
 - For Day Trade: Focus on immediate, actionable insights
@@ -138,38 +149,68 @@ Your specific research task: {subject.description}
 - Format your response for easy integration into a final report
 
 Begin your research now."""
-        
+
         return instructions
+
+    def _build_research_prompt(
+        self,
+        subject: ResearchSubject,
+        ticker: str,
+        trade_type: str,
+        focus_hint: str = "",
+    ) -> str:
+        """
+        Build the user-facing research prompt for a subject.
+
+        Args:
+            subject: ResearchSubject object
+            ticker: Stock ticker symbol
+            trade_type: Type of trade
+            focus_hint: Optional per-subject focus hint
+
+        Returns:
+            Formatted research prompt string
+        """
+        base_prompt = subject.prompt_template.format(ticker=ticker)
+
+        if focus_hint:
+            base_prompt += f"\n\nSpecific focus for this analysis: {focus_hint}"
+
+        return base_prompt
     
     def research_subject(
         self,
         ticker: str,
         subject: ResearchSubject,
         trade_type: str,
-        context: str = ""
+        focus_hint: str = "",
     ) -> Dict[str, Any]:
         """
         Research a specific subject for a ticker.
-        
+
         Args:
             ticker: Stock ticker symbol
             subject: ResearchSubject to investigate
             trade_type: Type of trade
-            context: Additional context from followup questions
-        
+            focus_hint: Per-subject focus hint from PlannerAgent
+
         Returns:
             Dictionary with research results:
             - subject_id: Subject ID
             - subject_name: Subject name
             - research_output: Agent's research output
             - sources: List of sources used
+            - focus_hint: The focus hint used for this subject
         """
-        # Get specialized instructions
-        instructions = self.get_specialized_instructions(subject, ticker, trade_type)
-        
-        # Format the research prompt
-        from research_subjects import format_subject_prompt
-        research_prompt = format_subject_prompt(subject, ticker, trade_type, context)
+        # Get specialized instructions (inject focus hint into system prompt)
+        instructions = self.get_specialized_instructions(
+            subject, ticker, trade_type, focus_hint
+        )
+
+        # Build the research prompt
+        research_prompt = self._build_research_prompt(
+            subject, ticker, trade_type, focus_hint
+        )
         
         # Create agent with specialized instructions
         agent = Agent(
@@ -268,9 +309,10 @@ Begin your research now."""
                 "research_output": research_output,
                 "sources": sources,
                 "ticker": ticker,
-                "trade_type": trade_type
+                "trade_type": trade_type,
+                "focus_hint": focus_hint,
             }
-            
+
         except Exception as e:
             error_msg = f"Error in specialized research for {subject.name}: {str(e)}"
             print(error_msg)
@@ -281,7 +323,8 @@ Begin your research now."""
                 "sources": [],
                 "ticker": ticker,
                 "trade_type": trade_type,
-                "error": str(e)
+                "focus_hint": focus_hint,
+                "error": str(e),
             }
 
 

--- a/src/synthesis_agent.py
+++ b/src/synthesis_agent.py
@@ -1,5 +1,9 @@
 """
-Synthesis agent that consolidates research outputs into a final business model report.
+Synthesis agent that consolidates research outputs into a final report.
+
+The report structure is now adaptive: sections are built from the subjects
+that were actually researched, ordered by plan priority, and framed
+according to trade type.
 """
 
 import os
@@ -9,256 +13,293 @@ from dotenv import load_dotenv
 
 from agents import Agent, Runner, trace, ModelSettings
 
+from research_plan import ResearchPlan
+from research_subjects import get_research_subject_by_id
+
 load_dotenv()
 
 # Maximum output tokens for synthesis agent (configurable via env)
-# Higher limit needed since synthesis agent integrates multiple specialized research outputs
 SYNTHESIS_AGENT_MAX_OUTPUT_TOKENS = int(
     os.getenv("SYNTHESIS_AGENT_MAX_OUTPUT_TOKENS", "8000")
 )
 
+# Trade-type framing labels used to instruct the synthesis agent
+_TRADE_TYPE_FRAMING = {
+    "Day Trade": "an actionable intraday/short-term briefing",
+    "Swing Trade": "a focused 1–14 day swing trade thesis",
+    "Investment": "a comprehensive long-term equity research report",
+}
+
 
 class SynthesisAgent:
     """Agent that synthesizes multiple research outputs into a comprehensive report."""
-    
+
     def __init__(self, api_key: str = None):
         """
         Initialize the synthesis agent.
-        
+
         Args:
             api_key: OpenAI API key (optional)
         """
         self.api_key = api_key or os.getenv("OPENAI_API_KEY")
         if not self.api_key:
-            raise ValueError("OpenAI API key is required. Set OPENAI_API_KEY environment variable.")
-    
+            raise ValueError(
+                "OpenAI API key is required. Set OPENAI_API_KEY environment variable."
+            )
+
+    # ─── Public API ──────────────────────────────────────────────────────────
+
     def synthesize_report(
         self,
         ticker: str,
         trade_type: str,
         research_outputs: Dict[str, Dict[str, Any]],
-        context: str = ""
+        plan: ResearchPlan,
     ) -> str:
         """
-        Synthesize all research outputs into a final business model report.
-        
+        Synthesize all research outputs into a final report.
+
         Args:
             ticker: Stock ticker symbol
             trade_type: Type of trade
-            research_outputs: Dictionary mapping subject_id -> research results
-            context: Additional context from followup questions
-        
+            research_outputs: Mapping of subject_id → research result dict
+            plan: ResearchPlan used to run this research session
+
         Returns:
             Complete synthesized report text
         """
-        # Build synthesis prompt
         synthesis_prompt = self._build_synthesis_prompt(
-            ticker,
-            trade_type,
-            research_outputs,
-            context
+            ticker, trade_type, research_outputs, plan
         )
-        
-        # Create synthesis agent
+
         agent = Agent(
             name="Synthesis Agent",
-            instructions=self._get_synthesis_instructions(ticker, trade_type),
+            instructions=self._get_synthesis_instructions(ticker, trade_type, plan),
             model="gpt-4o",
-            tools=[],  # Synthesis agent doesn't need tools, it works with provided data
+            tools=[],
             model_settings=ModelSettings(
                 temperature=0.7,
-                max_output_tokens=SYNTHESIS_AGENT_MAX_OUTPUT_TOKENS
-            )
+                max_output_tokens=SYNTHESIS_AGENT_MAX_OUTPUT_TOKENS,
+            ),
         )
-        
-        # Execute synthesis
+
         try:
-            with trace("Report Synthesis", metadata={
-                "ticker": ticker,
-                "trade_type": trade_type,
-                "subjects_count": str(len(research_outputs))  # Fixed: cast to string for tracing API
-            }):
-                # Run in a thread to avoid event loop conflicts (similar to specialized agents)
-                # This ensures Runner.run_sync() works even when called from a context with an active event loop
-                def _run_synthesis_in_thread():
+            with trace(
+                "Report Synthesis",
+                metadata={
+                    "ticker": ticker,
+                    "trade_type": trade_type,
+                    "subjects_count": str(len(research_outputs)),
+                },
+            ):
+                def _run():
                     return Runner.run_sync(agent, synthesis_prompt, max_turns=10)
-                
+
                 with ThreadPoolExecutor(max_workers=1) as executor:
-                    future = executor.submit(_run_synthesis_in_thread)
-                    result = future.result()
-            
-            # Extract output
-            if hasattr(result, 'final_output'):
-                report = result.final_output
-            elif hasattr(result, 'output'):
-                report = result.output
+                    result = executor.submit(_run).result()
+
+            if hasattr(result, "final_output"):
+                return result.final_output
+            elif hasattr(result, "output"):
+                return result.output
             elif isinstance(result, str):
-                report = result
-            else:
-                report = str(result)
-            
-            return report
-            
+                return result
+            return str(result)
+
         except Exception as e:
             error_msg = f"Error synthesizing report: {str(e)}"
             print(error_msg)
             return error_msg
-    
-    def _get_synthesis_instructions(self, ticker: str, trade_type: str) -> str:
-        """
-        Get system instructions for the synthesis agent.
-        
-        Args:
-            ticker: Stock ticker symbol
-            trade_type: Type of trade
-        
-        Returns:
-            System instructions string
-        """
+
+    # ─── Instructions ────────────────────────────────────────────────────────
+
+    def _get_synthesis_instructions(
+        self, ticker: str, trade_type: str, plan: ResearchPlan
+    ) -> str:
         from src.date_utils import get_datetime_context_string
-        
-        # Get current date/time context
+
         datetime_context = get_datetime_context_string()
-        
-        return f"""You are a senior equity research analyst synthesizing specialized research findings into a comprehensive business model report for {ticker}.
+        framing = _TRADE_TYPE_FRAMING.get(trade_type, "a research report")
+        trade_context_block = (
+            f"\n**User's stated goals / context:**\n{plan.trade_context}\n"
+            if plan.trade_context
+            else ""
+        )
+
+        return f"""You are a senior equity research analyst synthesizing specialized research findings into {framing} for {ticker}.
 
 {datetime_context}
-
+{trade_context_block}
 **Your Task:**
-Integrate and structure research findings from multiple specialized research agents into a comprehensive, detailed business model report. Your role is to PRESERVE and ORGANIZE all detailed information, NOT to summarize or condense it.
+Integrate research findings from multiple specialized agents into a structured, detailed report.
+Your role is to PRESERVE and ORGANIZE all detailed information, NOT to summarize or condense it.
 
 **CRITICAL: Detail Preservation Requirements**
-- **PRESERVE ALL SPECIFIC DATA**: Include all metrics, numbers, percentages, dollar amounts, and quantitative data points from the research outputs
-- **PRESERVE ALL FACTS**: Include all specific facts, findings, and qualitative insights from specialized agents
-- **PRESERVE ALL EXAMPLES**: Include specific examples, case studies, and concrete details provided by research agents
-- **INTEGRATE, DON'T SUMMARIZE**: Your job is to integrate information into a structured format, not to condense or summarize away details
-- **MINIMUM DETAIL REQUIREMENTS**: Each major section should include at least 3-5 specific data points, metrics, or detailed facts from the research outputs
-- **INCLUDE DIRECT QUOTES**: When key metrics or critical findings are provided, include them directly with their exact values/statements
-- **CROSS-REFERENCE INFORMATION**: Where information from different research subjects relates to each other, make those connections explicit
+- **PRESERVE ALL SPECIFIC DATA**: Include all metrics, numbers, percentages, dollar amounts, and quantitative data points
+- **PRESERVE ALL FACTS**: Include all specific facts, findings, and qualitative insights
+- **INTEGRATE, DON'T SUMMARIZE**: Integrate information into a structured format without losing depth
+- **MINIMUM DETAIL**: Each major section should include at least 3–5 specific data points or facts
+- **CROSS-REFERENCE**: Where information from different subjects relates, make those connections explicit
 
-**Report Structure:**
-1. **Executive Summary** - Comprehensive overview including key metrics and main findings
-2. **Products and Services** - Detailed description of all products/services with specific features, capabilities, and details
-3. **Revenue Breakdown** - Detailed revenue analysis with specific numbers, percentages, trends, and segment breakdowns
-4. **Value Propositions and Key Clients** - Detailed value propositions with specific examples, major clients, and customer relationship details
-5. **Buying Process** - Comprehensive description of the buying process with specific details about decision-makers, sales cycles, and procurement processes
-6. **Seasonality** - Detailed seasonal patterns with specific quarterly data, trends, and cyclical factors
-7. **Margin Structure** - Detailed margin analysis with specific percentages, trends, and segment-level profitability data
-8. **Business Model Overview** - Integrated view connecting all aspects with specific details and metrics
-9. **Sources and Citations** - All sources cited from the research with proper attribution
-
-**Trade Type Context:** {trade_type}
-- Adjust report depth and focus based on trade type
-- For Day Trade: Emphasize immediate, actionable insights while preserving all relevant details
-- For Swing Trade: Emphasize near-term factors while maintaining comprehensive detail
-- For Investment: Provide comprehensive, long-term analysis with full detail preservation
+**Trade Type Framing:** {trade_type} — frame this as {framing}.
+- Day Trade: Emphasize immediacy, catalysts, price action, and actionability.
+- Swing Trade: Emphasize near-term thesis, earnings, sector dynamics.
+- Investment: Provide full depth — valuation, moat, management, long-term growth.
 
 **Guidelines:**
-- **INTEGRATION OVER SUMMARIZATION**: Integrate all research findings seamlessly while preserving their depth and detail
-- **DATA POINT PRESERVATION**: Include specific numbers, percentages, dollar amounts, dates, and quantitative metrics from research outputs
-- **FACT PRESERVATION**: Include all specific facts, findings, examples, and qualitative insights
-- **STRUCTURE WITHOUT REDUCTION**: Organize information into the report structure without losing detail or condensing content
-- **CONNECTIONS AND CONTEXT**: Draw connections between different research subjects where relevant, using the detailed information provided
-- Maintain consistency across sections while preserving all unique details
-- Cite all sources from the research outputs with proper attribution
-- Use clear, professional language while maintaining comprehensive detail
-- Structure the report for easy reading and reference without sacrificing information density
-
-**Important:**
-- Only use information provided in the research outputs
+- Only use information from the provided research outputs
 - Do not add information not present in the research findings
-- **DO NOT summarize away details** - preserve all specific metrics, numbers, and facts
-- Clearly cite sources for all claims
+- Cite all sources from the research outputs
 - If information is missing for a section, note it clearly
-- **Ensure the report is comprehensive, detailed, and fully utilizes all research findings**"""
-    
+- Ensure the report is comprehensive and fully utilizes all research findings"""
+
+    # ─── Section Builder ─────────────────────────────────────────────────────
+
+    def _build_report_sections(
+        self, trade_type: str, subject_ids_run: List[str]
+    ) -> str:
+        """
+        Build a dynamic ordered section list for the report.
+
+        Always opens with Executive Summary and closes with Risk Factors
+        (if researched) and Sources.
+
+        Args:
+            trade_type: Type of trade
+            subject_ids_run: Ordered list of subject IDs that were researched
+
+        Returns:
+            Numbered section list as a string for injection into the prompt
+        """
+        # Build subject name map for labelling
+        subject_names: Dict[str, str] = {}
+        subject_descriptions: Dict[str, str] = {}
+        for sid in subject_ids_run:
+            try:
+                s = get_research_subject_by_id(sid)
+                subject_names[sid] = s.name
+                subject_descriptions[sid] = s.description
+            except ValueError:
+                subject_names[sid] = sid
+                subject_descriptions[sid] = ""
+
+        sections = ["1. **Executive Summary** — Key findings, recommendation, and top metrics"]
+
+        section_num = 2
+        for sid in subject_ids_run:
+            if sid == "risk_factors":
+                # Risk Factors goes near the end; skip here and add below
+                continue
+            name = subject_names.get(sid, sid)
+            desc = subject_descriptions.get(sid, "")
+            sections.append(
+                f"{section_num}. **{name}**"
+                + (f" — {desc}" if desc else "")
+            )
+            section_num += 1
+
+        # Risk Factors near the end if it was researched
+        if "risk_factors" in subject_ids_run:
+            sections.append(
+                f"{section_num}. **Risk Factors** — Key risks: operational, financial, regulatory, and macro"
+            )
+            section_num += 1
+
+        sections.append(
+            f"{section_num}. **Key Takeaways** — 5–7 bullets, each with a specific metric or fact; "
+            "cover growth, margin, competitive position, near-term catalyst, and primary risk"
+        )
+        section_num += 1
+        sections.append(f"{section_num}. **Sources and Citations** — All sources with proper attribution")
+
+        return "\n".join(sections)
+
+    # ─── Prompt Builder ──────────────────────────────────────────────────────
+
     def _build_synthesis_prompt(
         self,
         ticker: str,
         trade_type: str,
         research_outputs: Dict[str, Dict[str, Any]],
-        context: str
+        plan: ResearchPlan,
     ) -> str:
-        """
-        Build the synthesis prompt with all research outputs.
-        
-        Args:
-            ticker: Stock ticker symbol
-            trade_type: Type of trade
-            research_outputs: Dictionary of research results
-            context: Additional context
-        
-        Returns:
-            Formatted synthesis prompt
-        """
         from src.date_utils import get_datetime_context_string
-        
-        # Get current date/time context
+
         datetime_context = get_datetime_context_string()
-        
+        framing = _TRADE_TYPE_FRAMING.get(trade_type, "a research report")
+
+        # Use plan subject order for output ordering; fall back to dict order
+        ordered_ids = [
+            sid for sid in plan.selected_subject_ids if sid in research_outputs
+        ]
+        # Include any subject not in the plan order (safety net)
+        for sid in research_outputs:
+            if sid not in ordered_ids:
+                ordered_ids.append(sid)
+
+        sections_text = self._build_report_sections(trade_type, ordered_ids)
+
         prompt_parts = [
-            f"**TASK: Synthesize specialized research findings into a comprehensive business model report for {ticker} ({trade_type})**",
+            f"**TASK: Synthesize research into {framing} for {ticker} ({trade_type})**",
             "",
             datetime_context,
             "",
-            "**CRITICAL INSTRUCTIONS - READ CAREFULLY:**",
+        ]
+
+        if plan.trade_context:
+            prompt_parts += [
+                "**User's stated goals / context (frame the report around this):**",
+                plan.trade_context,
+                "",
+            ]
+
+        prompt_parts += [
+            "**CRITICAL INSTRUCTIONS:**",
             "",
-            f"The specialized research agents below have conducted detailed, in-depth research on different aspects of {ticker}'s business model. Each agent has provided comprehensive findings with specific data points, metrics, numbers, facts, and detailed analysis.",
+            f"Specialized agents have researched {len(ordered_ids)} subjects on {ticker}.",
+            "PRESERVE ALL DETAILS — do not summarize away specific numbers, facts, or examples.",
             "",
-            "**YOUR RESPONSIBILITY:**",
-            "- **PRESERVE ALL DETAILS**: Include ALL specific metrics, numbers, percentages, dollar amounts, dates, and quantitative data from each research output",
-            "- **PRESERVE ALL FACTS**: Include ALL specific facts, findings, examples, and qualitative insights from each research output",
-            "- **INTEGRATE, DON'T SUMMARIZE**: Your job is to integrate this detailed information into a well-structured report, NOT to condense or summarize away the details",
-            "- **USE ALL INFORMATION**: Fully utilize all the detailed research findings - specialized agents have done comprehensive work that should be preserved in the final report",
-            "- **MAINTAIN DEPTH**: Maintain the depth and specificity of analysis provided by the specialized research agents",
-            "- **INCLUDE SPECIFIC DATA**: Each section of your report should include specific data points, metrics, and detailed information - avoid high-level summaries",
-            "- **CROSS-REFERENCE**: Where information from different research subjects connects, make those relationships explicit using the detailed data provided",
-            "",
-            "The specialized agents have invested significant effort in gathering detailed information. Your synthesis should reflect and preserve this comprehensive research, not reduce it to bullet points or high-level summaries.",
+            "**Report Structure to follow (in this order):**",
+            sections_text,
             "",
             "**Research Findings from Specialized Agents:**",
-            ""
+            "",
         ]
-        
-        # Add each research output
-        for subject_id, result in research_outputs.items():
-            subject_name = result.get("subject_name", subject_id)
+
+        for sid in ordered_ids:
+            result = research_outputs[sid]
+            subject_name = result.get("subject_name", sid)
             research_output = result.get("research_output", "No research output available")
+            focus_hint = result.get("focus_hint", "")
             sources = result.get("sources", [])
-            
-            prompt_parts.append(f"### {subject_name} - Detailed Research Output")
+
+            prompt_parts.append(f"### {subject_name}")
+            if focus_hint:
+                prompt_parts.append(f"*User focus for this section: {focus_hint}*")
             prompt_parts.append("")
-            prompt_parts.append("**Comprehensive Research Findings (preserve all details from this output):**")
             prompt_parts.append(research_output)
-            
+
             if sources:
                 prompt_parts.append("")
-                prompt_parts.append("**Sources Used by This Research Agent:**")
+                prompt_parts.append("**Sources:**")
                 for i, source in enumerate(sources, 1):
                     prompt_parts.append(f"{i}. {source}")
-            
-            prompt_parts.append("")
-            prompt_parts.append("---")
-            prompt_parts.append("")
-        
-        if context:
-            prompt_parts.append("")
-            prompt_parts.append("**Additional Context from User:**")
-            prompt_parts.append(context)
-            prompt_parts.append("")
-        
-        prompt_parts.append("")
-        prompt_parts.append("**FINAL INSTRUCTIONS:**")
-        prompt_parts.append("")
-        prompt_parts.append("Now create a comprehensive, detailed business model report that:")
-        prompt_parts.append("1. Integrates all the detailed research findings above into a well-structured format")
-        prompt_parts.append("2. Preserves ALL specific metrics, numbers, facts, and detailed information from each research output")
-        prompt_parts.append("3. Includes specific data points (percentages, dollar amounts, dates, quantities) throughout the report")
-        prompt_parts.append("4. Maintains the depth and comprehensiveness of the specialized research")
-        prompt_parts.append("5. Clearly cites all sources from the research outputs")
-        prompt_parts.append("6. Draws connections between different research subjects where relevant")
-        prompt_parts.append("")
-        prompt_parts.append("Remember: The goal is comprehensive integration of detailed information, NOT summarization or condensation. Use all the detailed findings provided by the specialized research agents.")
-        
-        return "\n".join(prompt_parts)
 
+            prompt_parts += ["", "---", ""]
+
+        prompt_parts += [
+            "",
+            "**FINAL INSTRUCTIONS:**",
+            "",
+            f"Write the {framing} now following the section structure above.",
+            "- Preserve ALL specific metrics, numbers, facts, and details from the research outputs.",
+            "- Maintain section order exactly as specified.",
+            "- Cite all sources.",
+            "- Draw connections between sections where relevant.",
+            "- The **Key Takeaways** section is REQUIRED. Write 5–7 bullet points.",
+            "  Each bullet must contain a specific metric or fact (no vague conclusions).",
+            "  Cover at minimum: one growth finding, one margin finding, one competitive finding,",
+            "  one near-term catalyst, and one primary risk.",
+        ]
+
+        return "\n".join(prompt_parts)

--- a/templates/chat.html
+++ b/templates/chat.html
@@ -141,19 +141,11 @@
         const input = document.getElementById('user_response');
         const chatMessages = document.getElementById('chat-messages');
         
-        // #region agent log
-        fetch('http://127.0.0.1:7242/ingest/27ce924a-188a-4f1b-bc7b-66a0f39e7341',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({location:'chat.html:185',message:'DOMContentLoaded - checking form elements',data:{formFound:!!form,inputFound:!!input,chatMessagesFound:!!chatMessages},timestamp:Date.now(),sessionId:'debug-session',runId:'run1',hypothesisId:'A'})}).catch(()=>{});
-        // #endregion
-        
         if (form && input && chatMessages) {
             form.addEventListener('submit', async function(e) {
                 e.preventDefault(); // Prevent default form submission
                 
                 const userMessage = input.value.trim();
-                
-                // #region agent log
-                fetch('http://127.0.0.1:7242/ingest/27ce924a-188a-4f1b-bc7b-66a0f39e7341',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({location:'chat.html:194',message:'Form submit - userMessage value',data:{userMessage:userMessage,userMessageLength:userMessage.length,inputValue:input.value},timestamp:Date.now(),sessionId:'debug-session',runId:'run1',hypothesisId:'A'})}).catch(()=>{});
-                // #endregion
                 
                 if (!userMessage) return;
                 
@@ -161,11 +153,6 @@
                 const formData = new FormData(form);
                 // Manually append userMessage to ensure it's included (disabled fields may not be captured)
                 formData.set('user_response', userMessage);
-                
-                // #region agent log
-                const formDataEntries = Array.from(formData.entries());
-                fetch('http://127.0.0.1:7242/ingest/27ce924a-188a-4f1b-bc7b-66a0f39e7341',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify({location:'chat.html:214',message:'FormData created and userMessage appended',data:{formDataEntries:formDataEntries,userResponseInFormData:formData.get('user_response'),userMessage:userMessage},timestamp:Date.now(),sessionId:'debug-session',runId:'post-fix-v2',hypothesisId:'B'})}).catch(()=>{});
-                // #endregion
                 
                 // Disable form while processing
                 const submitButton = form.querySelector('button[type="submit"]');

--- a/test_nvda_research.py
+++ b/test_nvda_research.py
@@ -1,0 +1,61 @@
+"""
+Test research call: NVDA, Investment trade type.
+Runs the full pipeline: PlannerAgent → ResearchOrchestrator → SynthesisAgent.
+Run from project root: python test_nvda_research.py
+"""
+
+import sys
+import os
+
+# Add src to path so relative imports work
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "src"))
+
+from dotenv import load_dotenv
+load_dotenv()
+
+from agent import StockResearchAgent
+
+TICKER = "NVDA"
+TRADE_TYPE = "Investment"
+
+def main():
+    print(f"\n{'='*60}")
+    print(f"TEST: {TICKER} | {TRADE_TYPE}")
+    print(f"{'='*60}\n")
+
+    agent = StockResearchAgent()
+    agent.current_ticker = TICKER
+    agent.current_trade_type = TRADE_TYPE
+
+    report = agent.generate_report(context="Long-term investment thesis. Focus on growth drivers, margin structure, and competitive position.")
+
+    print(f"\n{'='*60}")
+    print("FINAL REPORT")
+    print(f"{'='*60}\n")
+    print(report)
+
+    # Spot-check key signals from the new prompts
+    checks = [
+        ("Growth decomposition framework", any(kw in report for kw in ["Volume", "Price × Mix", "NRR", "TPV", "CAGR"])),
+        ("Margin tree language", any(kw in report for kw in ["Gross →", "EBITDA", "FCF", "margin tree", "operating leverage"])),
+        ("Moat framework", any(kw in report for kw in ["switching cost", "network effect", "moat", "Switching cost"])),
+        ("Key Takeaways section", "Key Takeaways" in report),
+        ("Quantified claims (% or $)", any(c in report for c in ["%", "$", "YoY", "bps"])),
+    ]
+
+    print(f"\n{'='*60}")
+    print("SPOT CHECKS")
+    print(f"{'='*60}")
+    all_pass = True
+    for label, passed in checks:
+        status = "PASS" if passed else "FAIL"
+        if not passed:
+            all_pass = False
+        print(f"  [{status}] {label}")
+
+    print(f"\n{'='*60}")
+    print(f"Result: {'ALL CHECKS PASSED' if all_pass else 'SOME CHECKS FAILED'}")
+    print(f"{'='*60}\n")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- **PlannerAgent** (`src/planner_agent.py`): New agent that dynamically selects research subjects and builds a `ResearchPlan` before dispatching parallel agents, replacing the static 12-subject approach.
- **Sharper specialized agents** (`src/specialized_agent.py`, `src/synthesis_agent.py`): Tightened prompts, enforced Key Takeaways sections in synthesis output, and improved research subject definitions (`src/research_subjects.py`).
- **MCP tool registration fix** (`src/agent.py`, `src/research_orchestrator.py`): Resolved specialized agents not having MCP tools registered, causing silent data gaps.
- **Report display fix** (`src/agent.py`): Decoupled report display from storage — `last_report_text` and a temp `current_report_id` are set immediately after synthesis so the chat UI renders the report even if `store_report()` fails. Storage wrapped in isolated try/except.
- **Remove debug instrumentation** (`templates/chat.html`): Removed 3 hardcoded `fetch()` calls posting to `localhost:7242`.

## Test plan

- [ ] Start Flask app and log in
- [ ] Submit a ticker + trade type; verify PlannerAgent selects subjects and logs the plan
- [ ] Answer orchestrator follow-up question(s); confirm `generate_report` tool fires
- [ ] Verify the full markdown report renders in the chat bubble after pipeline completes
- [ ] Verify terminal shows storage step (success or `⚠ Report storage failed` warning) — never `current_report_id = None`
- [ ] Confirm no `fetch` calls to `127.0.0.1:7242` appear in browser DevTools Network tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)