### PR TITLE
fix: use PORT env var and fix cursor/connection close formatting

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -884,7 +884,7 @@ def main():
     
     app.run(
         host='127.0.0.1',
-        port=5000,
+        port=int(os.getenv('PORT', 5000)),
         debug=True
     )
 

--- a/src/database.py
+++ b/src/database.py
@@ -1044,7 +1044,8 @@ class DatabaseManager:
             raise RuntimeError(f"Failed to log CSV import: {e}")
         finally:
             if connection and connection.is_connected():
-                cursor.close()                connection.close()
+                cursor.close()                
+                connection.close()
 
 
 # Global instance


### PR DESCRIPTION
## Summary
- Read port from `PORT` env variable instead of hardcoded 5000
- Fix formatting: split `cursor.close()` and `connection.close()` onto separate lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)