### PR TITLE
feat: add portfolio value history chart with monthly data

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -29,6 +29,7 @@ from werkzeug.security import generate_password_hash, check_password_hash
 
 from agent import create_agent, StockResearchAgent
 from portfolio.portfolio_service import get_portfolio_service
+from portfolio.history_service import get_history_service
 from data_providers import DataProviderFactory
 from report_storage import ReportStorage
 from pdf_generator import get_pdf_generator
@@ -910,6 +911,18 @@ def delete_transaction(transaction_id: str):
         session['status_message'] = f'❌ Error: {str(e)}'
 
     return redirect(url_for('portfolio'))
+
+
+@app.route('/api/portfolio/<portfolio_id>/history')
+@login_required
+def portfolio_history(portfolio_id):
+    """Return monthly portfolio value history as JSON."""
+    portfolio = get_portfolio_service().get_portfolio(portfolio_id)
+    if not portfolio or portfolio.get('user_id') != session['user_id']:
+        return jsonify({'error': 'Not found'}), 404
+    history_service = get_history_service()
+    data = history_service.get_monthly_values(portfolio_id)
+    return jsonify(data)
 
 
 # ============================================================================

--- a/src/database.py
+++ b/src/database.py
@@ -1127,6 +1127,37 @@ class DatabaseManager:
                 cursor.close()
                 connection.close()
 
+    def get_all_portfolio_transactions(self, portfolio_id: str) -> List[Dict[str, Any]]:
+        """Get all transactions for a portfolio joined with holding symbol and asset_type."""
+        connection = None
+        try:
+            connection = self.get_connection()
+            cursor = connection.cursor(dictionary=True)
+
+            cursor.execute("""
+                SELECT t.transaction_id, t.holding_id, t.transaction_type, t.quantity,
+                       t.price_per_unit, t.fees, t.transaction_date, t.notes,
+                       h.symbol, h.asset_type
+                FROM transactions t
+                JOIN holdings h ON t.holding_id = h.holding_id
+                WHERE h.portfolio_id = %s
+                ORDER BY t.transaction_date ASC
+            """, (portfolio_id,))
+
+            results = cursor.fetchall()
+            for result in results:
+                result['quantity'] = Decimal(str(result['quantity']))
+                result['price_per_unit'] = Decimal(str(result['price_per_unit']))
+                result['fees'] = Decimal(str(result['fees']))
+            return results
+
+        except Error as e:
+            raise RuntimeError(f"Failed to get portfolio transactions: {e}")
+        finally:
+            if connection and connection.is_connected():
+                cursor.close()
+                connection.close()
+
     # ==================== CSV Import Logging ====================
 
     def log_csv_import(

--- a/src/portfolio/history_service.py
+++ b/src/portfolio/history_service.py
@@ -1,0 +1,215 @@
+"""
+Portfolio value history service - computes monthly portfolio values.
+"""
+
+import os
+import calendar
+import requests
+from decimal import Decimal
+from datetime import datetime, date
+from typing import List, Dict, Optional
+
+from data_providers.crypto_provider import CryptoDataProvider
+
+_ALPHA_VANTAGE_URL = "https://www.alphavantage.co/query"
+
+# Module-level price cache: symbol -> {'prices': {date_str: float}, 'fetched_at': datetime}
+_price_cache: Dict[str, dict] = {}
+_CACHE_TTL_HOURS = 24
+
+
+def _cache_valid(entry: dict) -> bool:
+    delta = datetime.utcnow() - entry['fetched_at']
+    return delta.total_seconds() < _CACHE_TTL_HOURS * 3600
+
+
+def _month_end_dates(months: int) -> List[date]:
+    """Return list of month-end dates ending with today, going back `months` months."""
+    today = date.today()
+    ends = []
+    year, month = today.year, today.month
+    for _ in range(months):
+        last_day = calendar.monthrange(year, month)[1]
+        ends.append(date(year, month, min(last_day, today.day if (year == today.year and month == today.month) else last_day)))
+        month -= 1
+        if month == 0:
+            month = 12
+            year -= 1
+    ends.reverse()
+    return ends
+
+
+class PortfolioHistoryService:
+
+    def __init__(self, db=None):
+        self._db = db
+
+    @property
+    def db(self):
+        if self._db is None:
+            from database import get_database_manager
+            self._db = get_database_manager()
+        return self._db
+
+    def get_monthly_values(self, portfolio_id: str, months: int = 12) -> List[dict]:
+        """
+        Compute monthly portfolio values for the past `months` months.
+
+        Returns:
+            List of {'date': 'Mar 2025', 'value': 12450.00}
+        """
+        transactions = self.db.get_all_portfolio_transactions(portfolio_id)
+
+        if not transactions:
+            month_ends = _month_end_dates(months)
+            return [{'date': d.strftime('%b %Y'), 'value': 0.0} for d in month_ends]
+
+        # Group transactions by symbol
+        by_symbol: Dict[str, list] = {}
+        asset_type_map: Dict[str, str] = {}
+        for txn in transactions:
+            sym = txn['symbol']
+            by_symbol.setdefault(sym, []).append(txn)
+            asset_type_map[sym] = txn['asset_type']
+
+        month_ends = _month_end_dates(months)
+
+        # Fetch price histories per symbol
+        stock_prices: Dict[str, Dict[str, float]] = {}
+        crypto_prices: Dict[str, Dict[str, float]] = {}
+
+        for sym, asset_type in asset_type_map.items():
+            if asset_type == 'stock':
+                stock_prices[sym] = self._get_stock_prices(sym)
+            else:
+                crypto_prices[sym] = self._get_crypto_prices(sym)
+
+        result = []
+        for month_end in month_ends:
+            total = 0.0
+            for sym, txns in by_symbol.items():
+                qty = self._qty_at_date(txns, month_end)
+                if qty <= 0:
+                    continue
+
+                asset_type = asset_type_map[sym]
+                if asset_type == 'stock':
+                    prices = stock_prices.get(sym, {})
+                else:
+                    prices = crypto_prices.get(sym, {})
+
+                price = self._lookup_price(prices, month_end, asset_type)
+                if price is not None:
+                    total += qty * price
+
+            result.append({'date': month_end.strftime('%b %Y'), 'value': round(total, 2)})
+
+        return result
+
+    def _qty_at_date(self, transactions: list, as_of: date) -> float:
+        """Replay transactions up to as_of date, return clamped quantity."""
+        qty = Decimal('0')
+        for txn in transactions:
+            txn_date = txn['transaction_date']
+            if isinstance(txn_date, datetime):
+                txn_date = txn_date.date()
+            if txn_date > as_of:
+                break
+            if txn['transaction_type'] == 'buy':
+                qty += txn['quantity']
+            else:
+                qty -= txn['quantity']
+        if qty < 0:
+            qty = Decimal('0')
+        return float(qty)
+
+    def _get_stock_prices(self, symbol: str) -> Dict[str, float]:
+        """Fetch monthly adjusted close prices from Alpha Vantage. Returns {YYYY-MM-DD: price}."""
+        global _price_cache
+        cache_key = f"stock:{symbol}"
+        if cache_key in _price_cache and _cache_valid(_price_cache[cache_key]):
+            return _price_cache[cache_key]['prices']
+
+        api_key = os.getenv('ALPHA_VANTAGE_API_KEY', '')
+        if not api_key:
+            return {}
+
+        try:
+            resp = requests.get(
+                _ALPHA_VANTAGE_URL,
+                params={
+                    'function': 'TIME_SERIES_MONTHLY_ADJUSTED',
+                    'symbol': symbol,
+                    'apikey': api_key,
+                },
+                timeout=15
+            )
+            if not resp.ok:
+                return {}
+            data = resp.json()
+            series = data.get('Monthly Adjusted Time Series', {})
+            prices = {k: float(v['5. adjusted close']) for k, v in series.items()}
+            _price_cache[cache_key] = {'prices': prices, 'fetched_at': datetime.utcnow()}
+            return prices
+        except Exception:
+            return {}
+
+    def _get_crypto_prices(self, symbol: str) -> Dict[str, float]:
+        """Fetch daily price history from CoinGecko. Returns {YYYY-MM-DD: price}."""
+        global _price_cache
+        cache_key = f"crypto:{symbol}"
+        if cache_key in _price_cache and _cache_valid(_price_cache[cache_key]):
+            return _price_cache[cache_key]['prices']
+
+        crypto_provider = CryptoDataProvider()
+        coin_id = crypto_provider._get_coin_id(symbol)
+        if not coin_id:
+            return {}
+
+        try:
+            resp = requests.get(
+                f"https://api.coingecko.com/api/v3/coins/{coin_id}/market_chart",
+                params={'vs_currency': 'usd', 'days': 400},
+                timeout=15
+            )
+            if not resp.ok:
+                return {}
+            data = resp.json()
+            prices_raw = data.get('prices', [])
+            prices: Dict[str, float] = {}
+            for ts_ms, price in prices_raw:
+                d = date.fromtimestamp(ts_ms / 1000)
+                prices[d.strftime('%Y-%m-%d')] = price
+            _price_cache[cache_key] = {'prices': prices, 'fetched_at': datetime.utcnow()}
+            return prices
+        except Exception:
+            return {}
+
+    def _lookup_price(self, prices: Dict[str, float], target: date, asset_type: str) -> Optional[float]:
+        """Find closest available price to target date."""
+        if not prices:
+            return None
+
+        target_str = target.strftime('%Y-%m-%d')
+        if target_str in prices:
+            return prices[target_str]
+
+        # For stocks: Alpha Vantage returns YYYY-MM-DD as last day of the month series
+        # Try searching backwards up to 31 days
+        for days_back in range(1, 32):
+            candidate = date.fromordinal(target.toordinal() - days_back)
+            candidate_str = candidate.strftime('%Y-%m-%d')
+            if candidate_str in prices:
+                return prices[candidate_str]
+
+        return None
+
+
+_history_service: Optional[PortfolioHistoryService] = None
+
+
+def get_history_service() -> PortfolioHistoryService:
+    global _history_service
+    if _history_service is None:
+        _history_service = PortfolioHistoryService()
+    return _history_service

--- a/templates/portfolio.html
+++ b/templates/portfolio.html
@@ -81,6 +81,12 @@
                 </div>
             </div>
 
+            <!-- Portfolio Value History Chart -->
+            <div class="bg-surface-dark rounded-3xl p-6 border border-border-dark mb-6">
+                <h2 class="font-display font-semibold text-lg mb-4">Portfolio Value</h2>
+                <canvas id="historyChart" height="80"></canvas>
+            </div>
+
             <!-- Holdings Table -->
             <div class="bg-surface-dark rounded-xl border border-border-dark overflow-hidden">
                 <div class="px-5 py-4 border-b border-border-dark">
@@ -183,4 +189,65 @@
     </main>
 
 {% include '_footer.html' %}
+
+<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+<script>
+(function () {
+    var portfolioId = {{ portfolio.portfolio_id | tojson }};
+    fetch('/api/portfolio/' + portfolioId + '/history')
+        .then(function (r) { return r.json(); })
+        .then(function (data) {
+            var labels = data.map(function (d) { return d.date; });
+            var values = data.map(function (d) { return d.value; });
+            var ctx = document.getElementById('historyChart');
+            if (!ctx) return;
+            new Chart(ctx, {
+                type: 'line',
+                data: {
+                    labels: labels,
+                    datasets: [{
+                        data: values,
+                        borderColor: '#22c55e',
+                        backgroundColor: 'transparent',
+                        borderWidth: 2,
+                        pointRadius: 3,
+                        pointBackgroundColor: '#22c55e',
+                        tension: 0.3,
+                    }]
+                },
+                options: {
+                    responsive: true,
+                    plugins: {
+                        legend: { display: false },
+                        tooltip: {
+                            callbacks: {
+                                label: function (ctx) {
+                                    return '$' + ctx.parsed.y.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+                                }
+                            }
+                        }
+                    },
+                    scales: {
+                        x: {
+                            grid: { color: '#292524' },
+                            ticks: { color: '#78716c' }
+                        },
+                        y: {
+                            grid: { color: '#292524' },
+                            ticks: {
+                                color: '#78716c',
+                                callback: function (v) {
+                                    return '$' + v.toLocaleString('en-US', { minimumFractionDigits: 0, maximumFractionDigits: 0 });
+                                }
+                            }
+                        }
+                    }
+                }
+            });
+        })
+        .catch(function () {
+            document.getElementById('historyChart').parentElement.innerHTML = '<p class="text-stone-500 text-sm text-center py-8">Could not load chart data</p>';
+        });
+}());
+</script>
 {% endblock %}

--- a/test_portfolio_history.py
+++ b/test_portfolio_history.py
@@ -1,0 +1,112 @@
+"""
+Tests for PortfolioHistoryService.
+"""
+
+import pytest
+from decimal import Decimal
+from datetime import datetime, date
+from unittest.mock import MagicMock, patch
+
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).parent / 'src'))
+
+from portfolio.history_service import PortfolioHistoryService
+
+
+def make_txn(symbol, asset_type, txn_type, qty, price, txn_date):
+    return {
+        'symbol': symbol,
+        'asset_type': asset_type,
+        'transaction_type': txn_type,
+        'quantity': Decimal(str(qty)),
+        'price_per_unit': Decimal(str(price)),
+        'transaction_date': txn_date,
+        'fees': Decimal('0'),
+    }
+
+
+class TestPortfolioHistoryService:
+
+    def setup_method(self):
+        self.db = MagicMock()
+        self.service = PortfolioHistoryService(db=self.db)
+
+    def test_returns_list_of_dicts(self):
+        """get_monthly_values returns a list."""
+        self.db.get_all_portfolio_transactions.return_value = []
+        result = self.service.get_monthly_values('portfolio-1')
+        assert isinstance(result, list)
+
+    def test_returns_12_months_by_default(self):
+        """Returns 12 month entries by default."""
+        self.db.get_all_portfolio_transactions.return_value = []
+        result = self.service.get_monthly_values('portfolio-1')
+        assert len(result) == 12
+
+    def test_each_entry_has_date_and_value(self):
+        """Each entry has 'date' (string) and 'value' (float)."""
+        self.db.get_all_portfolio_transactions.return_value = []
+        result = self.service.get_monthly_values('portfolio-1')
+        for entry in result:
+            assert 'date' in entry
+            assert 'value' in entry
+            assert isinstance(entry['date'], str)
+            assert isinstance(entry['value'], float)
+
+    def test_zero_value_when_no_transactions(self):
+        """All months are 0.0 when portfolio has no transactions."""
+        self.db.get_all_portfolio_transactions.return_value = []
+        result = self.service.get_monthly_values('portfolio-1')
+        for entry in result:
+            assert entry['value'] == 0.0
+
+    def test_holding_acquired_after_month_end_contributes_nothing(self):
+        """A buy after a month-end date contributes 0 value for that month."""
+        # Transaction dated very recently — should not affect most historical months
+        txn = make_txn('AAPL', 'stock', 'buy', 10, 150, datetime(2099, 1, 1))
+        self.db.get_all_portfolio_transactions.return_value = [txn]
+
+        with patch.object(self.service, '_get_stock_prices', return_value={'2099-01-31': 200.0}):
+            result = self.service.get_monthly_values('portfolio-1')
+
+        # All months in normal 12-month window should be 0
+        for entry in result:
+            assert entry['value'] == 0.0
+
+    def test_sell_clamped_to_zero(self):
+        """Sells that bring quantity negative are clamped to 0."""
+        buy = make_txn('AAPL', 'stock', 'buy', 5, 100, datetime(2020, 1, 1))
+        sell = make_txn('AAPL', 'stock', 'sell', 10, 100, datetime(2020, 2, 1))
+        self.db.get_all_portfolio_transactions.return_value = [buy, sell]
+
+        with patch.object(self.service, '_get_stock_prices', return_value={}):
+            result = self.service.get_monthly_values('portfolio-1')
+
+        for entry in result:
+            assert entry['value'] >= 0.0
+
+    def test_skips_symbol_when_price_unavailable(self):
+        """If price fetch fails for a symbol, that symbol contributes 0 (no error)."""
+        txn = make_txn('UNKNOWNSYM', 'stock', 'buy', 5, 100, datetime(2020, 1, 1))
+        self.db.get_all_portfolio_transactions.return_value = [txn]
+
+        with patch.object(self.service, '_get_stock_prices', return_value={}):
+            result = self.service.get_monthly_values('portfolio-1')
+
+        assert isinstance(result, list)
+        assert len(result) == 12
+
+    def test_custom_months_parameter(self):
+        """Accepts a custom months parameter."""
+        self.db.get_all_portfolio_transactions.return_value = []
+        result = self.service.get_monthly_values('portfolio-1', months=6)
+        assert len(result) == 6
+
+    def test_date_format_is_readable(self):
+        """Date strings look like 'Jan 2025'."""
+        self.db.get_all_portfolio_transactions.return_value = []
+        result = self.service.get_monthly_values('portfolio-1', months=1)
+        # Should have a month name abbreviation + space + 4-digit year
+        import re
+        assert re.match(r'[A-Z][a-z]{2} \d{4}', result[0]['date'])


### PR DESCRIPTION
Adds a Chart.js line chart to the portfolio dashboard showing total portfolio value over the last 12 months, computed by replaying transactions against historical prices from Alpha Vantage and CoinGecko.

- New PortfolioHistoryService with 24h module-level price cache
- New get_all_portfolio_transactions DB query joining transactions + holdings
- New /api/portfolio/<id>/history route with ownership verification
- Chart card inserted above holdings table in portfolio.html