### PR TITLE
fix(agents): fallback tool priority, perplexity error signaling, budg…

### DIFF
--- a/src/agents/specialized_node.py
+++ b/src/agents/specialized_node.py
@@ -60,6 +60,42 @@ def _get_instructions(
 {focus_hint}
 Prioritize this focus while still covering the full subject area.
 """
+    qualitative_subjects = {
+        "growth_drivers", "competitive_position", "sector_macro",
+        "risk_factors", "management_quality",
+    }
+    fundamental_subjects = {
+        "earnings_financials", "revenue_breakdown", "valuation",
+        "margin_structure", "company_overview",
+    }
+
+    subject_id_key = subject.id
+
+    if subject_id_key in qualitative_subjects:
+        tool_priority = (
+            "1. perplexity_research — primary source for qualitative analysis, expert opinions, growth narratives\n"
+            "2. nimble_web_search — fallback if Perplexity fails; search for analyst reports, news, industry trends\n"
+            "3. yfinance_fundamentals or yfinance_analyst — if relevant financial context supports the subject"
+        )
+    elif subject_id_key == "news_catalysts":
+        tool_priority = (
+            "1. news_sentiment (Alpha Vantage) — primary source for recent news and sentiment scores\n"
+            "2. perplexity_research — for upcoming catalysts, event calendars, recent developments\n"
+            "3. nimble_web_search — fallback if both above fail"
+        )
+    elif subject_id_key == "technical_price_action":
+        tool_priority = (
+            "1. yfinance_options — options market data (IV, open interest, volume) for market sentiment\n"
+            "2. perplexity_research — technical commentary, support/resistance levels\n"
+            "3. nimble_web_search — fallback if Perplexity fails"
+        )
+    else:
+        tool_priority = (
+            "1. yfinance_fundamentals — primary source for all fundamental data (profile, financials, ratios, EPS)\n"
+            "2. yfinance_analyst — analyst price targets, recommendations, upgrades/downgrades\n"
+            "3. news_sentiment (Alpha Vantage) or perplexity_research — for context and recent developments"
+        )
+
     return f"""You are a specialized research analyst focusing on {subject.name} for {ticker}.
 
 {datetime_context}
@@ -75,13 +111,13 @@ Your specific research task: {subject.description}
 - For Swing Trade: Focus on near-term factors (1-14 days)
 - For Investment: Focus on comprehensive, long-term analysis
 
-**Available Tools:**
-- yfinance_fundamentals: Company profile, valuation ratios, income statement, balance sheet, cash flow, EPS — use this first for all fundamental data
-- yfinance_analyst: Analyst price targets, buy/sell/hold recommendations, upgrades/downgrades
-- yfinance_ownership: Institutional holders, mutual fund holders, insider transactions
-- yfinance_options: Options chain summary (open interest, IV, volume) — use for technical and risk subjects
-- Alpha Vantage NEWS_SENTIMENT: News articles with sentiment scores — use for news and catalysts research
-- Perplexity Research: Use for real-time information, news, expert analysis, qualitative insights
+**Tool Priority (use in this order):**
+{tool_priority}
+
+**Fallback Rule:**
+If a tool returns {{"status": "failed"}} or an error, immediately try the next tool in priority order.
+Do NOT retry the same tool. Once you have data from at least one successful tool call, write your research output.
+Never end your response with "I need more steps" — always produce findings from whatever data you have.
 
 **Output Requirements:**
 1. Provide comprehensive research findings on {subject.name}
@@ -92,6 +128,8 @@ Your specific research task: {subject.description}
    - Supporting data
    - Sources and citations
    - Any relevant context or analysis
+
+**IMPORTANT: You MUST call at least one tool before writing your response. Never rely on your training data — always fetch current data using the tools above.**
 
 Begin your research now."""
 
@@ -187,6 +225,15 @@ def specialized_node(state: dict) -> dict:
                     else:
                         output_text = str(content)
                     break
+
+            _empty_phrases = ["sorry, need more steps", "need more steps to process"]
+            if any(p in output_text.lower() for p in _empty_phrases):
+                logger.warning(
+                    "%s: agent hit recursion limit (output: %r), clearing output",
+                    subject_id,
+                    output_text[:80],
+                )
+                output_text = ""
 
             logger.info(
                 "%s: %s chars, %s/%s tokens",

--- a/src/langchain_tools.py
+++ b/src/langchain_tools.py
@@ -201,8 +201,17 @@ def create_nimble_tools(nimble_client: NimbleClient) -> List[StructuredTool]:
         )
 
     def perplexity_research(query: str, focus: str = "general") -> str:
-        result = nimble_client.perplexity_research(query, focus)
-        return json.dumps({"research": result, "status": "success"})
+        try:
+            result = nimble_client.perplexity_research(query, focus)
+            if isinstance(result, str) and result.startswith("[Nimble Perplexity"):
+                return json.dumps({
+                    "status": "failed",
+                    "error": result,
+                    "suggestion": "Try nimble_web_search or a yfinance tool instead.",
+                })
+            return json.dumps({"research": result, "status": "success"})
+        except Exception as e:
+            return json.dumps({"status": "failed", "error": f"perplexity_research failed: {e}"})
 
     return [
         StructuredTool.from_function(

--- a/src/nimble_client.py
+++ b/src/nimble_client.py
@@ -14,6 +14,7 @@ load_dotenv()
 NIMBLE_API_BASE = "https://sdk.nimbleway.com/v1"
 NIMBLE_TIMEOUT_SECONDS = float(os.getenv("NIMBLE_TIMEOUT_SECONDS", "60.0"))
 NIMBLE_FAST_TIMEOUT_SECONDS = float(os.getenv("NIMBLE_FAST_TIMEOUT_SECONDS", "15.0"))
+PERPLEXITY_TIMEOUT_SECONDS = float(os.getenv("PERPLEXITY_TIMEOUT_SECONDS", "30.0"))
 
 _FOCUS_PREFIXES = {
     "news": "As a financial news research assistant focusing on recent events and sources: ",
@@ -135,7 +136,7 @@ class NimbleClient:
         prompt = f"{prefix}{query}"
         payload = {"agent": "perplexity", "params": {"prompt": prompt}}
         try:
-            with httpx.Client(timeout=self.timeout) as client:
+            with httpx.Client(timeout=PERPLEXITY_TIMEOUT_SECONDS) as client:
                 resp = client.post(
                     f"{NIMBLE_API_BASE}/agents/run",
                     headers=self._headers(),
@@ -145,7 +146,7 @@ class NimbleClient:
                 data = resp.json()
                 return data["data"]["parsing"]["answer"]
         except httpx.TimeoutException as e:
-            return f"[Nimble Perplexity timeout] Exceeded {self.timeout:.0f}s: {e}"
+            return f"[Nimble Perplexity timeout] Exceeded {PERPLEXITY_TIMEOUT_SECONDS:.0f}s: {e}"
         except Exception as e:
             return f"[Nimble Perplexity error] Request failed: {e}"
 

--- a/src/spend_budget.py
+++ b/src/spend_budget.py
@@ -95,16 +95,14 @@ def compute_effective_specialized_settings_from_estimates(
     min_max_output_tokens: int,
     input_rate_usd_per_1k_tokens: float,
     output_rate_usd_per_1k_tokens: float,
-    min_subject_count: int = 3,
 ) -> Dict[str, Any]:
     """
-    Compute effective specialized depth (turns + subject count + output token caps)
+    Compute effective specialized depth (turns + output token caps)
     so the estimated spend stays within `spend_budget_usd`.
 
-    Reduction order (quality-preserving):
+    Reduction order:
       1. Reduce turns to minimum
-      2. Reduce subject count (drop lowest-priority subjects first)
-      3. Reduce output tokens (last resort, clamped to floor)
+      2. Reduce output tokens (last resort, clamped to floor)
 
     Returns:
         - effective_max_turns
@@ -122,9 +120,7 @@ def compute_effective_specialized_settings_from_estimates(
 
     min_max_turns = max(1, int(min_max_turns))
     min_max_output_tokens = max(1, int(min_max_output_tokens))
-    min_subject_count = max(1, min(int(min_subject_count), subject_count))
-
-    # Approximate input tokens per subject (used when subject count varies).
+    # Approximate input tokens per subject.
     input_per_subject_per_turn = (
         total_input_tokens_per_turn / subject_count if subject_count > 0 else 0
     )
@@ -175,28 +171,15 @@ def compute_effective_specialized_settings_from_estimates(
             "budget_exhausted": False,
         }
 
-    # Step 3: min turns, reduce subject count while keeping base output quality.
-    for n in range(subject_count - 1, min_subject_count - 1, -1):
-        est = estimate(effective_turns, n, base_max_output_tokens)
-        if est <= spend_budget_usd:
-            return {
-                "effective_max_turns": effective_turns,
-                "effective_max_output_tokens": base_max_output_tokens,
-                "effective_subject_count": n,
-                "estimated_spend_usd": est,
-                "budget_exhausted": False,
-            }
-
-    # Step 4: last resort — min turns + min subjects, solve for output tokens.
-    effective_subjects = min_subject_count
+    # Step 3: last resort — min turns + all subjects, solve for output tokens.
     input_cost = (
-        input_per_subject_per_turn * effective_subjects * effective_turns / 1000.0
+        input_per_subject_per_turn * subject_count * effective_turns / 1000.0
     ) * input_rate_usd_per_1k_tokens
     remaining = spend_budget_usd - input_cost
     if remaining <= 0:
         effective_out = min_max_output_tokens
     else:
-        denom = (effective_subjects * effective_turns) * (
+        denom = (subject_count * effective_turns) * (
             output_rate_usd_per_1k_tokens / 1000.0
         )
         effective_out = int(remaining / denom) if denom > 0 else min_max_output_tokens
@@ -204,13 +187,13 @@ def compute_effective_specialized_settings_from_estimates(
         min_max_output_tokens, min(base_max_output_tokens, effective_out)
     )
 
-    est = estimate(effective_turns, effective_subjects, effective_out)
+    est = estimate(effective_turns, subject_count, effective_out)
     budget_exhausted = est > spend_budget_usd
 
     return {
         "effective_max_turns": effective_turns,
         "effective_max_output_tokens": effective_out,
-        "effective_subject_count": effective_subjects,
+        "effective_subject_count": subject_count,
         "estimated_spend_usd": est,
         "budget_exhausted": budget_exhausted,
     }
@@ -304,8 +287,6 @@ def compute_effective_specialized_settings_from_plan(
     min_max_output_tokens = int(
         os.getenv("RESEARCH_SPEND_BUDGET_USD_MIN_MAX_OUTPUT_TOKENS", "512")
     )
-    min_subject_count = int(os.getenv("RESEARCH_SPEND_BUDGET_USD_MIN_SUBJECTS", "3"))
-
     total_input_tokens_per_turn = estimate_total_input_tokens_per_turn(
         ticker=ticker,
         trade_type=trade_type,
@@ -323,7 +304,6 @@ def compute_effective_specialized_settings_from_plan(
         min_max_output_tokens=min_max_output_tokens,
         input_rate_usd_per_1k_tokens=input_rate,
         output_rate_usd_per_1k_tokens=output_rate,
-        min_subject_count=min_subject_count,
     )
 
 


### PR DESCRIPTION
…et subject trimming removed

- specialized_node: add per-subject-type tool priority instructions (qualitative subjects: Perplexity → nimble_web_search → yfinance; fundamental subjects: yfinance first; news: NEWS_SENTIMENT first; technical: yfinance_options first)
- specialized_node: add explicit fallback rule instructing agent to try next tool on failure and always produce output — never end with "need more steps"
- specialized_node: detect "sorry, need more steps" output and clear it to empty string so synthesis does not receive garbage from recursion-limit hits
- langchain_tools: fix perplexity_research handler — add try/except and detect Nimble error strings, return {"status": "failed"} instead of wrapping errors as "success"
- nimble_client: add PERPLEXITY_TIMEOUT_SECONDS env var (default 30s) so Perplexity timeout is tunable independently of other Nimble calls (was always 60s)
- spend_budget: remove subject trimming (step 2) from budget reduction order — budget now only reduces turns then output tokens, never silently drops subjects