### PR TITLE
Fix CI tests: align with PriceCacheService, LangGraph, ticker notes, …

### DIFF
--- a/tests/test_budget_hooks.py
+++ b/tests/test_budget_hooks.py
@@ -1,5 +1,7 @@
 from unittest.mock import MagicMock
 
+from langchain_core.messages import AIMessage
+
 
 def test_fan_out_includes_effective_caps():
     """_fan_out passes planner-populated budget fields through to each specialized_node Send."""
@@ -65,11 +67,9 @@ def test_specialized_node_uses_effective_caps(monkeypatch):
         agent = MagicMock()
 
         def _invoke(_payload, config=None):
-            captured["recursion_limit"] = (config or {}).get("recursion_limit")
-            fake_msg = MagicMock()
-            fake_msg.content = "OUTPUT"
-            fake_msg.tool_calls = None
-            return {"messages": [fake_msg]}
+                captured["recursion_limit"] = (config or {}).get("recursion_limit")
+                fake_msg = AIMessage(content="OUTPUT")
+                return {"messages": [fake_msg]}
 
         agent.invoke.side_effect = _invoke
         return agent

--- a/tests/test_flask_ticker_notes.py
+++ b/tests/test_flask_ticker_notes.py
@@ -47,7 +47,14 @@ def test_ticker_page_renders_reports_and_notes(api_client):
         1,
     )
     mock_db = MagicMock()
-    mock_db.get_ticker_note.return_value = "<p>Existing thesis note</p>"
+    mock_db.get_ticker_notes.return_value = [
+        {
+            "id": 1,
+            "title": "Thesis",
+            "content": "<p>Existing thesis note</p>",
+            "created_at": None,
+        }
+    ]
 
     with patch.object(app_module, "ReportStorage", return_value=mock_storage):
         with patch("database.get_database_manager", return_value=mock_db):
@@ -71,9 +78,9 @@ def test_save_ticker_notes_persists_content(api_client):
         resp = api_client.post("/ticker/AAPL/notes", data={"content": "<p>My note</p>"})
 
     assert resp.status_code == 302
-    mock_db.upsert_ticker_note.assert_called_once()
-    call_args = mock_db.upsert_ticker_note.call_args[0]
+    mock_db.create_ticker_note.assert_called_once()
+    call_args = mock_db.create_ticker_note.call_args[0]
     assert call_args[0] == "u1"
     assert call_args[1] == "AAPL"
-    assert "My note" in call_args[2]
+    assert "My note" in call_args[3]
 

--- a/tests/test_price_cache_fastlane.py
+++ b/tests/test_price_cache_fastlane.py
@@ -1,197 +1,222 @@
 """
-Tests for price_cache fastlane in portfolio_service.get_holdings().
-Verifies cache-first flow: fresh cache hits skip providers, stale/missing hit providers,
-and freshly fetched prices are upserted back into the cache.
+Tests for price cache behavior in portfolio_service.get_holdings().
+
+Production uses PriceCacheService: missing symbols refresh synchronously; stale rows
+trigger a background refresh (Thread patched to run inline here). The HTTP response
+still shows cached values for stale rows; refresh updates DB for the next request.
 """
 
-import pytest
 import sys
+import threading
 from pathlib import Path
-from unittest.mock import MagicMock, patch, call
 from decimal import Decimal
 from datetime import datetime, timedelta
+from unittest.mock import MagicMock
 
-sys.path.insert(0, str(Path(__file__).parent / 'src'))
+import pytest
+
+# pytest.ini sets pythonpath = src; keep a fallback for direct runs
+_ROOT = Path(__file__).resolve().parents[1]
+if str(_ROOT / "src") not in sys.path:
+    sys.path.insert(0, str(_ROOT / "src"))
 
 
-def make_holding(symbol, asset_type='stock'):
+def make_holding(symbol, asset_type="stock"):
     return {
-        'symbol': symbol,
-        'asset_type': asset_type,
-        'total_quantity': Decimal('10'),
-        'total_cost_basis': Decimal('1000'),
-        'average_cost': Decimal('100'),
+        "symbol": symbol,
+        "asset_type": asset_type,
+        "total_quantity": Decimal("10"),
+        "total_cost_basis": Decimal("1000"),
+        "average_cost": Decimal("100"),
     }
 
 
 def make_cache_row(symbol, price, age_minutes=0):
-    """Return a price_cache row dict with last_updated set to age_minutes ago."""
     return {
-        'symbol': symbol,
-        'price': float(price),
-        'change_percent': 1.5,
-        'asset_type': 'stock',
-        'display_name': None,
-        'last_updated': datetime.utcnow() - timedelta(minutes=age_minutes),
+        "symbol": symbol,
+        "price": float(price),
+        "change_percent": 1.5,
+        "asset_type": "stock",
+        "display_name": None,
+        "last_updated": datetime.utcnow() - timedelta(minutes=age_minutes),
     }
 
 
 @pytest.fixture
-def service():
-    """PortfolioService with all external deps mocked."""
+def service(monkeypatch):
     from portfolio.portfolio_service import PortfolioService
-    svc = PortfolioService()
+    from price_cache_service import PriceCacheService
 
-    # Mock database
+    svc = PortfolioService()
     mock_db = MagicMock()
     svc._db = mock_db
 
-    # Mock provider factory + providers
     mock_stock_provider = MagicMock()
     mock_crypto_provider = MagicMock()
     mock_factory = MagicMock()
-    mock_factory.get_provider.side_effect = lambda t: mock_stock_provider if t == 'stock' else mock_crypto_provider
+    mock_factory.get_provider.side_effect = (
+        lambda t: mock_stock_provider if t == "stock" else mock_crypto_provider
+    )
     svc._provider_factory = mock_factory
 
     svc._mock_db = mock_db
     svc._mock_stock_provider = mock_stock_provider
     svc._mock_crypto_provider = mock_crypto_provider
 
+    real_pcs = PriceCacheService(mock_db, mock_stock_provider, mock_crypto_provider)
+    monkeypatch.setattr("price_cache_service._instance", None)
+    monkeypatch.setattr("price_cache_service.get_price_cache_service", lambda: real_pcs)
+
+    class ImmediateThread:
+        def __init__(
+            self,
+            group=None,
+            target=None,
+            name=None,
+            args=(),
+            kwargs=None,
+            *,
+            daemon=None,
+        ):
+            self._target = target
+            self._args = args or ()
+            self._kwargs = dict(kwargs or {})
+
+        def start(self):
+            if self._target:
+                self._target(*self._args, **self._kwargs)
+
+    monkeypatch.setattr(threading, "Thread", ImmediateThread)
+
     return svc
 
 
 class TestCacheHitSkipsProviders:
-    """When all symbols are fresh in cache, providers are never called."""
-
     def test_fresh_cache_skips_stock_provider(self, service):
-        service._mock_db.get_holdings.return_value = [make_holding('AAPL')]
+        service._mock_db.get_holdings.return_value = [make_holding("AAPL")]
         service._mock_db.get_cached_prices.return_value = {
-            'AAPL': make_cache_row('AAPL', 150.00, age_minutes=5),  # fresh (< 15 min)
+            "AAPL": make_cache_row("AAPL", 150.00, age_minutes=5),
         }
 
-        result = service.get_holdings('p-1', with_prices=True)
+        result = service.get_holdings("p-1", with_prices=True)
 
-        service._mock_stock_provider.get_prices_batch.assert_not_called()
-        assert result[0]['current_price'] == Decimal('150.00')
+        service._mock_stock_provider.get_prices_batch_warmup.assert_not_called()
+        assert result[0]["current_price"] == Decimal("150.00")
 
     def test_fresh_cache_skips_crypto_provider(self, service):
-        service._mock_db.get_holdings.return_value = [make_holding('BTC', 'crypto')]
+        service._mock_db.get_holdings.return_value = [make_holding("BTC", "crypto")]
+        row = make_cache_row("BTC", 65000.00, age_minutes=10)
+        row["asset_type"] = "crypto"
+        service._mock_db.get_cached_prices.return_value = {"BTC": row}
+
+        result = service.get_holdings("p-1", with_prices=True)
+
+        service._mock_crypto_provider.get_prices_with_change.assert_not_called()
+        assert result[0]["current_price"] == Decimal("65000.00")
+
+
+class TestStaleCacheBackgroundRefresh:
+    def test_stale_response_still_shows_cached_price_provider_refreshes_db(self, service):
+        service._mock_db.get_holdings.return_value = [make_holding("AAPL")]
         service._mock_db.get_cached_prices.return_value = {
-            'BTC': make_cache_row('BTC', 65000.00, age_minutes=10),
+            "AAPL": make_cache_row("AAPL", 140.00, age_minutes=20),
+        }
+        service._mock_stock_provider.get_prices_batch_warmup.return_value = {
+            "AAPL": {"price": Decimal("155.00"), "change_percent": None},
         }
 
-        result = service.get_holdings('p-1', with_prices=True)
+        result = service.get_holdings("p-1", with_prices=True)
 
-        service._mock_crypto_provider.get_prices_batch.assert_not_called()
-        assert result[0]['current_price'] == Decimal('65000.00')
+        service._mock_stock_provider.get_prices_batch_warmup.assert_called_once_with(
+            ["AAPL"]
+        )
+        assert result[0]["current_price"] == Decimal("140.00")
+        service._mock_db.upsert_price_cache.assert_called()
 
-
-class TestStaleCacheHitsProviders:
-    """When cache is stale or missing, providers are called and cache is upserted."""
-
-    def test_stale_cache_fetches_from_provider(self, service):
-        service._mock_db.get_holdings.return_value = [make_holding('AAPL')]
-        service._mock_db.get_cached_prices.return_value = {
-            'AAPL': make_cache_row('AAPL', 140.00, age_minutes=20),  # stale (> 15 min)
-        }
-        service._mock_stock_provider.get_prices_batch.return_value = {
-            'AAPL': Decimal('155.00')
-        }
-        service._mock_stock_provider.get_change_percent = MagicMock(return_value=None)
-
-        result = service.get_holdings('p-1', with_prices=True)
-
-        service._mock_stock_provider.get_prices_batch.assert_called_once_with(['AAPL'])
-        assert result[0]['current_price'] == Decimal('155.00')
-
-    def test_missing_cache_fetches_from_provider(self, service):
-        service._mock_db.get_holdings.return_value = [make_holding('TSLA')]
-        service._mock_db.get_cached_prices.return_value = {}  # no cache at all
-        service._mock_stock_provider.get_prices_batch.return_value = {
-            'TSLA': Decimal('200.00')
+    def test_missing_cache_fetches_from_provider_sync(self, service):
+        service._mock_db.get_holdings.return_value = [make_holding("TSLA")]
+        service._mock_db.get_cached_prices.return_value = {}
+        service._mock_stock_provider.get_prices_batch_warmup.return_value = {
+            "TSLA": {"price": Decimal("200.00"), "change_percent": None},
         }
 
-        result = service.get_holdings('p-1', with_prices=True)
+        result = service.get_holdings("p-1", with_prices=True)
 
-        service._mock_stock_provider.get_prices_batch.assert_called_once_with(['TSLA'])
-        assert result[0]['current_price'] == Decimal('200.00')
+        service._mock_stock_provider.get_prices_batch_warmup.assert_called_once_with(
+            ["TSLA"]
+        )
+        assert result[0]["current_price"] == Decimal("200.00")
 
     def test_fetched_price_is_upserted_to_cache(self, service):
-        service._mock_db.get_holdings.return_value = [make_holding('AAPL')]
+        service._mock_db.get_holdings.return_value = [make_holding("AAPL")]
         service._mock_db.get_cached_prices.return_value = {}
-        service._mock_stock_provider.get_prices_batch.return_value = {
-            'AAPL': Decimal('160.00')
+        service._mock_stock_provider.get_prices_batch_warmup.return_value = {
+            "AAPL": {"price": Decimal("160.00"), "change_percent": None},
         }
 
-        service.get_holdings('p-1', with_prices=True)
+        service.get_holdings("p-1", with_prices=True)
 
         service._mock_db.upsert_price_cache.assert_called_once()
         args = service._mock_db.upsert_price_cache.call_args[0]
-        assert args[0] == 'AAPL'
-        assert args[1] == 'stock'
-        assert Decimal(str(args[2])) == Decimal('160.00')
+        assert args[0] == "AAPL"
+        assert args[1] == "stock"
+        assert Decimal(str(args[2])) == Decimal("160.00")
 
 
 class TestPartialCacheHit:
-    """When some symbols are fresh and some are stale/missing."""
-
-    def test_only_stale_symbols_sent_to_provider(self, service):
+    def test_only_missing_symbols_sent_to_provider(self, service):
         service._mock_db.get_holdings.return_value = [
-            make_holding('AAPL'),
-            make_holding('TSLA'),
+            make_holding("AAPL"),
+            make_holding("TSLA"),
         ]
         service._mock_db.get_cached_prices.return_value = {
-            'AAPL': make_cache_row('AAPL', 150.00, age_minutes=5),   # fresh
-            # TSLA missing from cache
+            "AAPL": make_cache_row("AAPL", 150.00, age_minutes=5),
         }
-        service._mock_stock_provider.get_prices_batch.return_value = {
-            'TSLA': Decimal('210.00')
+        service._mock_stock_provider.get_prices_batch_warmup.return_value = {
+            "TSLA": {"price": Decimal("210.00"), "change_percent": None},
         }
 
-        result = service.get_holdings('p-1', with_prices=True)
+        result = service.get_holdings("p-1", with_prices=True)
 
-        # Provider called only for TSLA
-        service._mock_stock_provider.get_prices_batch.assert_called_once_with(['TSLA'])
+        service._mock_stock_provider.get_prices_batch_warmup.assert_called_once_with(
+            ["TSLA"]
+        )
 
-        aapl = next(h for h in result if h['symbol'] == 'AAPL')
-        tsla = next(h for h in result if h['symbol'] == 'TSLA')
-        assert aapl['current_price'] == Decimal('150.00')
-        assert tsla['current_price'] == Decimal('210.00')
+        aapl = next(h for h in result if h["symbol"] == "AAPL")
+        tsla = next(h for h in result if h["symbol"] == "TSLA")
+        assert aapl["current_price"] == Decimal("150.00")
+        assert tsla["current_price"] == Decimal("210.00")
 
 
 class TestNoPricesNoProviderCall:
-    """When with_prices=False, cache and providers are never touched."""
-
     def test_no_provider_call_when_with_prices_false(self, service):
-        service._mock_db.get_holdings.return_value = [make_holding('AAPL')]
+        service._mock_db.get_holdings.return_value = [make_holding("AAPL")]
 
-        result = service.get_holdings('p-1', with_prices=False)
+        result = service.get_holdings("p-1", with_prices=False)
 
         service._mock_db.get_cached_prices.assert_not_called()
-        service._mock_stock_provider.get_prices_batch.assert_not_called()
-        assert result[0]['price_available'] is False
+        service._mock_stock_provider.get_prices_batch_warmup.assert_not_called()
+        assert result[0]["price_available"] is False
 
 
 class TestCacheTTL:
-    """TTL boundary: exactly 15 min is stale; 14 min 59 sec is fresh."""
-
-    def test_exactly_15_min_is_stale(self, service):
-        service._mock_db.get_holdings.return_value = [make_holding('AAPL')]
+    def test_exactly_15_min_triggers_background_refresh(self, service):
+        service._mock_db.get_holdings.return_value = [make_holding("AAPL")]
         service._mock_db.get_cached_prices.return_value = {
-            'AAPL': make_cache_row('AAPL', 140.00, age_minutes=15),
+            "AAPL": make_cache_row("AAPL", 140.00, age_minutes=15),
         }
-        service._mock_stock_provider.get_prices_batch.return_value = {}
+        service._mock_stock_provider.get_prices_batch_warmup.return_value = {}
 
-        service.get_holdings('p-1', with_prices=True)
+        service.get_holdings("p-1", with_prices=True)
 
-        service._mock_stock_provider.get_prices_batch.assert_called_once()
+        service._mock_stock_provider.get_prices_batch_warmup.assert_called_once()
 
     def test_just_under_15_min_is_fresh(self, service):
-        service._mock_db.get_holdings.return_value = [make_holding('AAPL')]
-        row = make_cache_row('AAPL', 150.00, age_minutes=0)
-        row['last_updated'] = datetime.utcnow() - timedelta(minutes=14, seconds=59)
-        service._mock_db.get_cached_prices.return_value = {'AAPL': row}
+        service._mock_db.get_holdings.return_value = [make_holding("AAPL")]
+        row = make_cache_row("AAPL", 150.00, age_minutes=0)
+        row["last_updated"] = datetime.utcnow() - timedelta(minutes=14, seconds=59)
+        service._mock_db.get_cached_prices.return_value = {"AAPL": row}
 
-        service.get_holdings('p-1', with_prices=True)
+        service.get_holdings("p-1", with_prices=True)
 
-        service._mock_stock_provider.get_prices_batch.assert_not_called()
+        service._mock_stock_provider.get_prices_batch_warmup.assert_not_called()

--- a/tests/test_report_isolation.py
+++ b/tests/test_report_isolation.py
@@ -26,6 +26,6 @@ def test_supabase_doc_mentions_rls():
     """Docs stay aligned with [STOA-4](/STOA/issues/STOA-4#document-plan) Supabase verification."""
     from pathlib import Path
 
-    doc = Path(__file__).resolve().parent / "docs" / "SUPABASE.md"
+    doc = Path(__file__).resolve().parents[1] / "docs" / "SUPABASE.md"
     text = doc.read_text(encoding="utf-8")
     assert "Row Level Security" in text or "RLS" in text

--- a/tests/test_research_graph_checkpointer.py
+++ b/tests/test_research_graph_checkpointer.py
@@ -15,11 +15,8 @@ Phase 2 — quality_gate_node:
 9. synthesis prompt has no missing-sections note when all subjects succeed
 """
 
-import uuid
 import sys
 import os
-
-import pytest
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "src"))
 
@@ -27,14 +24,11 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "src"))
 _GOOD_TEXT = "x" * 200
 
 
-def test_checkpointer_attached():
+def test_graph_compiled_without_checkpointer():
+    """Research graph is compiled without a checkpointer (no thread-scoped persistence)."""
     from research_graph import research_graph
-    from langgraph.checkpoint.memory import MemorySaver
 
-    assert research_graph.checkpointer is not None, "No checkpointer attached"
-    assert isinstance(research_graph.checkpointer, MemorySaver), (
-        f"Expected MemorySaver, got {type(research_graph.checkpointer).__name__}"
-    )
+    assert getattr(research_graph, "checkpointer", None) is None
 
 
 def test_expected_nodes_present():
@@ -45,62 +39,40 @@ def test_expected_nodes_present():
         assert expected in nodes, f"Missing node: {expected}"
 
 
-def test_invoke_without_thread_id_raises():
-    """LangGraph requires thread_id in config when a checkpointer is attached."""
+def test_invoke_does_not_require_thread_id_without_checkpointer():
+    """Without a checkpointer, invoke is not required to receive configurable.thread_id."""
     from research_graph import research_graph
     from langgraph.graph.state import CompiledStateGraph
 
     assert isinstance(research_graph, CompiledStateGraph)
-
-    with pytest.raises(ValueError, match="thread_id"):
-        research_graph.invoke({
-            "ticker": "AAPL",
-            "trade_type": "investment",
-            "conversation_context": "",
-            "plan": None,
-            "subject_id": "",
-            "research_outputs": {},
-            "report_text": "",
-            "report_id": "",
-            "user_id": None,
-            "emitter": None,
-        })
+    assert research_graph.checkpointer is None
 
 
-def test_run_research_passes_thread_id(monkeypatch):
-    """run_research should pass a valid UUID thread_id in the invoke config."""
+def test_run_research_passes_run_name(monkeypatch):
+    """run_research passes a human-readable run_name in the invoke config."""
     import research_graph as rg
 
     captured = {}
 
     def mock_invoke(state, config=None):
         captured["config"] = config
-        # return minimal state so run_research doesn't crash
         return {**state, "report_id": "test-id", "report_text": "ok"}
 
     monkeypatch.setattr(rg.research_graph, "invoke", mock_invoke)
 
     rg.run_research("AAPL", "investment")
 
-    assert "config" in captured, "invoke was not called with config"
-    cfg = captured["config"]
-    assert "configurable" in cfg, "config missing 'configurable' key"
-    thread_id = cfg["configurable"].get("thread_id")
-    assert thread_id is not None, "thread_id not set in config"
-
-    # must be a valid UUID
-    parsed = uuid.UUID(thread_id)
-    assert str(parsed) == thread_id, "thread_id is not a valid UUID"
+    assert captured.get("config", {}).get("run_name") == "AAPL Research"
 
 
-def test_each_run_gets_unique_thread_id(monkeypatch):
-    """Two calls to run_research must use different thread_ids."""
+def test_each_run_gets_distinct_run_name_for_different_tickers(monkeypatch):
+    """Different tickers produce different run_name values (LangSmith / tracing)."""
     import research_graph as rg
 
-    ids = []
+    names = []
 
     def mock_invoke(state, config=None):
-        ids.append(config["configurable"]["thread_id"])
+        names.append((config or {}).get("run_name"))
         return {**state, "report_id": "x", "report_text": "ok"}
 
     monkeypatch.setattr(rg.research_graph, "invoke", mock_invoke)
@@ -108,8 +80,7 @@ def test_each_run_gets_unique_thread_id(monkeypatch):
     rg.run_research("AAPL", "investment")
     rg.run_research("NVDA", "swing")
 
-    assert len(ids) == 2
-    assert ids[0] != ids[1], "Both runs used the same thread_id"
+    assert names == ["AAPL Research", "NVDA Research"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_unified_warmup.py
+++ b/tests/test_unified_warmup.py
@@ -5,10 +5,11 @@ and concurrent batch fetch in price_refresh.py.
 import sys
 import os
 import unittest
-from unittest.mock import MagicMock, patch, call
+from unittest.mock import MagicMock, patch
 from datetime import datetime, timedelta
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), 'src'))
+_REPO_ROOT = os.path.normpath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, os.path.join(_REPO_ROOT, "src"))
 
 
 class TestGetWatchedSymbolsForUser(unittest.TestCase):
@@ -78,21 +79,26 @@ class TestWarmPortfolioCacheFreshnessCheck(unittest.TestCase):
         mock_svc.list_portfolios.return_value = portfolios
 
         mock_stock_provider = MagicMock()
-        # Convert flat {sym: price} to new {sym: {'price': ..., 'change_percent': ...}} format
         mock_stock_provider.get_prices_batch_warmup.return_value = {
             sym: {"price": price, "change_percent": None}
             for sym, price in stock_prices.items()
         }
         mock_crypto_provider = MagicMock()
-        mock_crypto_provider.get_prices_batch.return_value = crypto_prices
+        mock_crypto_provider.get_prices_with_change.return_value = {
+            sym: {"price": price, "change_percent": None}
+            for sym, price in crypto_prices.items()
+        }
 
-        with patch('app.get_portfolio_service', return_value=mock_svc), \
-             patch('app.DataProviderFactory') as mock_factory:
-            mock_factory.get_provider.side_effect = lambda t: (
-                mock_stock_provider if t == 'stock' else mock_crypto_provider
-            )
+        from price_cache_service import PriceCacheService
+
+        mock_pcs = PriceCacheService(mock_db, mock_stock_provider, mock_crypto_provider)
+
+        with patch("app.get_portfolio_service", return_value=mock_svc), patch(
+            "price_cache_service.get_price_cache_service", return_value=mock_pcs
+        ):
             from app import _warm_portfolio_cache
-            _warm_portfolio_cache('user_1')
+
+            _warm_portfolio_cache("user_1")
 
         return mock_db, mock_stock_provider, mock_crypto_provider
 
@@ -101,7 +107,6 @@ class TestWarmPortfolioCacheFreshnessCheck(unittest.TestCase):
         Uses datetime.now() to match MySQL TIMESTAMP (naive local-server-time)."""
         fresh_time = datetime.now() - timedelta(minutes=5)
         portfolios = [{'portfolio_id': 1}]
-        holdings = {'AAPL': 'stock', 'BTC': 'crypto'}
         holdings_map = {1: [
             {'symbol': 'AAPL', 'asset_type': 'stock', 'total_quantity': '10'},
             {'symbol': 'BTC', 'asset_type': 'crypto', 'total_quantity': '1'},
@@ -114,7 +119,7 @@ class TestWarmPortfolioCacheFreshnessCheck(unittest.TestCase):
             portfolios, holdings_map, [], cached
         )
         stock_prov.get_prices_batch_warmup.assert_not_called()
-        crypto_prov.get_prices_batch.assert_not_called()
+        crypto_prov.get_prices_with_change.assert_not_called()
 
     def test_fetches_stale_symbols(self):
         """Symbols older than 15 min should be fetched."""
@@ -207,7 +212,7 @@ class TestWarmPortfolioCacheFreshnessCheck(unittest.TestCase):
         )
         # Should NOT fetch — data is fresh (only 5 min old)
         stock_prov.get_prices_batch_warmup.assert_not_called()
-        crypto_prov.get_prices_batch.assert_not_called()
+        crypto_prov.get_prices_with_change.assert_not_called()
 
     def test_stale_symbol_using_local_time_is_fetched(self):
         """Companion to local-time regression: a symbol 20 min old (datetime.now())
@@ -228,38 +233,33 @@ class TestWarmPortfolioCacheFreshnessCheck(unittest.TestCase):
 
 
 class TestPriceRefreshBatchStock(unittest.TestCase):
-    """Tests that _do_refresh uses concurrent batch for stocks (no sleep)."""
+    """_do_refresh delegates to PriceCacheService.refresh (single code path)."""
 
-    def test_do_refresh_uses_batch_warmup_for_stocks(self):
-        """_do_refresh should call get_prices_batch_warmup, not get_price_with_change."""
+    def test_do_refresh_calls_price_cache_service(self):
         from watchlist.price_refresh import PriceRefreshJob
 
         mock_db = MagicMock()
         mock_db.get_all_watched_symbols.return_value = [
-            {'symbol': 'AAPL', 'asset_type': 'stock'},
-            {'symbol': 'TSLA', 'asset_type': 'stock'},
+            {"symbol": "AAPL", "asset_type": "stock"},
+            {"symbol": "TSLA", "asset_type": "stock"},
         ]
-        # All symbols stale (not in cache) so refresh proceeds
-        mock_db.get_cached_prices.return_value = {}
+        mock_db.get_all_cached_prices.return_value = {}
 
-        mock_provider = MagicMock()
-        mock_provider.get_prices_batch_warmup.return_value = {
-            'AAPL': {'price': 175.0, 'change_percent': 1.5},
-            'TSLA': {'price': 250.0, 'change_percent': -0.8},
-        }
-
-        mock_factory = MagicMock()
-        mock_factory.get_provider_for_symbol.return_value = (mock_provider, 'stock')
+        mock_pcs = MagicMock()
 
         job = PriceRefreshJob()
         job._db = mock_db
-        job._provider_factory = mock_factory
 
-        job._do_refresh()
+        with patch(
+            "price_cache_service.get_price_cache_service", return_value=mock_pcs
+        ):
+            job._do_refresh()
 
-        mock_provider.get_prices_batch_warmup.assert_called_once()
-        # Must NOT call per-stock sequential method
-        mock_provider.get_price_with_change.assert_not_called()
+        mock_pcs.refresh.assert_called_once()
+        pairs = mock_pcs.refresh.call_args[0][0]
+        symbols = {s for s, _ in pairs}
+        self.assertIn("AAPL", symbols)
+        self.assertIn("TSLA", symbols)
 
     def test_do_refresh_no_time_sleep(self):
         """No time.sleep calls should remain in _do_refresh for stock fetching."""

--- a/tests/test_warm_portfolio_cache.py
+++ b/tests/test_warm_portfolio_cache.py
@@ -9,7 +9,8 @@ import unittest
 from unittest.mock import MagicMock, patch, call
 
 # Add src to path so we can import from app.py
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), 'src'))
+_REPO_ROOT = os.path.normpath(os.path.join(os.path.dirname(__file__), ".."))
+sys.path.insert(0, os.path.join(_REPO_ROOT, "src"))
 
 
 class TestWarmPortfolioCache(unittest.TestCase):
@@ -20,7 +21,7 @@ class TestWarmPortfolioCache(unittest.TestCase):
         import importlib
         # We import only the function — avoid full Flask app initialization
         import ast
-        app_path = os.path.join(os.path.dirname(__file__), 'src', 'app.py')
+        app_path = os.path.join(_REPO_ROOT, "src", "app.py")
         with open(app_path) as f:
             tree = ast.parse(f.read())
         func_names = [
@@ -45,7 +46,7 @@ class TestWarmPortfolioCache(unittest.TestCase):
             import importlib.util
 
             # Parse and extract _warm_portfolio_cache source
-            app_path = os.path.join(os.path.dirname(__file__), 'src', 'app.py')
+            app_path = os.path.join(_REPO_ROOT, "src", "app.py")
             with open(app_path) as f:
                 source = f.read()
 
@@ -79,7 +80,7 @@ class TestWarmPortfolioCache(unittest.TestCase):
 
         with patch('portfolio.portfolio_service.get_portfolio_service', return_value=mock_svc):
             import ast
-            app_path = os.path.join(os.path.dirname(__file__), 'src', 'app.py')
+            app_path = os.path.join(_REPO_ROOT, "src", "app.py")
             with open(app_path) as f:
                 source = f.read()
             tree = ast.parse(source)
@@ -100,7 +101,7 @@ class TestWarmPortfolioCache(unittest.TestCase):
     def test_warm_portfolio_cache_thread_spawn_in_login_required(self):
         """login_required block must spawn a daemon thread targeting _warm_portfolio_cache."""
         import ast
-        app_path = os.path.join(os.path.dirname(__file__), 'src', 'app.py')
+        app_path = os.path.join(_REPO_ROOT, "src", "app.py")
         with open(app_path) as f:
             source = f.read()
 

--- a/tests/test_watchlist.py
+++ b/tests/test_watchlist.py
@@ -4,7 +4,7 @@ Tests for watchlist service — WatchlistService unit tests using mocked DB and 
 
 import sys
 import os
-from unittest.mock import MagicMock, patch, call
+from unittest.mock import MagicMock, patch
 from decimal import Decimal
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), 'src'))
@@ -93,12 +93,13 @@ class TestWatchlistService:
         }
         self.mock_factory.get_provider_for_symbol.return_value = (mock_provider, 'crypto')
 
-        self.service.add_symbol('wl-1', 'BTC')
+        mock_pcs = MagicMock()
+        with patch("price_cache_service.get_price_cache_service", return_value=mock_pcs):
+            self.service.add_symbol('wl-1', 'BTC')
 
-        assert self.mock_db.upsert_price_cache.called
-        call_args = self.mock_db.upsert_price_cache.call_args[0]
-        assert call_args[0] == 'BTC'
-        assert call_args[1] == 'crypto'
+        mock_pcs.refresh.assert_called_once()
+        assert mock_pcs.refresh.call_args[0][0] == [('BTC', 'crypto')]
+        assert mock_pcs.refresh.call_args[1].get('force') is True
 
     # ── Pins ─────────────────────────────────────────────────
 


### PR DESCRIPTION
…and paths

- Report isolation: point SUPABASE doc check at repo docs/
- Research graph: no checkpointer; assert run_name in invoke config
- Price cache fastlane: PriceCacheService + inline thread; warmup API
- Warm portfolio tests: correct src/app.py path; unified warmup uses PCS
- Flask ticker notes: get_ticker_notes / create_ticker_note
- Budget hooks: AIMessage so tool_calls does not block output
- Watchlist: assert price_cache_service.refresh(force=True)

Made-with: Cursor