### PR TITLE
feat: agent pipeline improvements from architecture review

### DIFF
--- a/src/agents/chat_agent.py
+++ b/src/agents/chat_agent.py
@@ -169,8 +169,9 @@ class ReportChatAgent:
         top_k: int = CHAT_TOP_K,
     ) -> Dict[str, Any]:
         """Answer a question about a report using a ReAct agent with report retrieval, IR search, and yfinance tools."""
-        print(
-            f"[ReportChat] answer_question called -- report_id={report_id}, ticker={ticker}, question={user_question[:80]!r}"
+        logger.debug(
+            "answer_question called -- report_id=%s, ticker=%s, question=%r",
+            report_id, ticker, user_question[:80],
         )
 
         tools = create_chat_tools(
@@ -208,7 +209,7 @@ class ReportChatAgent:
             messages.append(HumanMessage(content=user_question))
 
         try:
-            print(f"[ReportChat] Running ReAct agent ({CHAT_MODEL}, recursion_limit={CHAT_RECURSION_LIMIT})...")
+            logger.debug("Running ReAct agent (%s, recursion_limit=%s)", CHAT_MODEL, CHAT_RECURSION_LIMIT)
             result = agent.invoke(
                 {"messages": messages},
                 config={"recursion_limit": CHAT_RECURSION_LIMIT},
@@ -245,7 +246,7 @@ class ReportChatAgent:
             if not sources and all_sources:
                 sources = [s for s in all_sources if s["chunk_type"] in ("report", "research")]
 
-            print(f"[ReportChat] Answer: {len(answer_text)} chars, {len(sources)} cited sources (of {len(all_sources)} total)")
+            logger.debug("Answer: %s chars, %s cited sources (of %s total)", len(answer_text), len(sources), len(all_sources))
             return {"answer": answer_text, "sources": sources}
 
         except Exception as e:

--- a/src/agents/planner_node.py
+++ b/src/agents/planner_node.py
@@ -59,7 +59,38 @@ Rules:
 - Order subjects by research importance for this specific situation.
 - Focus hints should be specific to user concerns; leave as "" when no particular focus applies.
 - trade_context is prose written for a synthesis agent, not bullet points.
-- reasoning is for logging only — be candid about your choices."""
+- reasoning is for logging only — be candid about your choices.
+
+<examples>
+Example 1 — Day Trade for TSLA, user concerned about earnings reaction:
+{{
+  "selected_subject_ids": ["news_catalysts", "technical_price_action", "valuation_metrics"],
+  "subject_focus": {{
+    "news_catalysts": "Focus on post-earnings price reaction and any new guidance from yesterday's call",
+    "technical_price_action": "Key intraday support/resistance levels and options flow around current price",
+    "valuation_metrics": ""
+  }},
+  "trade_context": "User is evaluating a day trade on TSLA following an earnings report. Primary concern is the post-earnings price reaction and whether intraday momentum supports a long entry.",
+  "reasoning": "Earnings just happened so news_catalysts is top priority. Technical levels matter most for day trade entry/exit. Valuation is secondary but included for context."
+}}
+
+Example 2 — Investment for AAPL, user focused on AI growth:
+{{
+  "selected_subject_ids": ["growth_drivers", "financial_health", "competitive_position", "valuation_metrics", "risk_factors", "management_quality", "sector_macro", "news_catalysts"],
+  "subject_focus": {{
+    "growth_drivers": "Focus on Apple Intelligence adoption rates, AI feature roadmap, and Services revenue acceleration",
+    "financial_health": "Highlight free cash flow trends and capital allocation toward AI/R&D",
+    "competitive_position": "Compare Apple's AI strategy vs Google, Samsung, and Microsoft in consumer devices",
+    "valuation_metrics": "Assess whether current premium is justified by AI-driven growth narrative",
+    "risk_factors": "Evaluate China regulatory risk and AI chip supply constraints",
+    "management_quality": "",
+    "sector_macro": "",
+    "news_catalysts": ""
+  }},
+  "trade_context": "User is considering a long-term investment in AAPL, specifically interested in whether Apple's AI push will drive the next growth phase. They want deep coverage of AI strategy and competitive positioning.",
+  "reasoning": "User's AI focus means growth_drivers and competitive_position are highest priority. Financial health and valuation ground the thesis in data. Risk factors cover China and supply chain concerns the user should know about."
+}}
+</examples>"""
 
 
 def _build_user_prompt(

--- a/src/agents/specialized_node.py
+++ b/src/agents/specialized_node.py
@@ -103,11 +103,7 @@ Your specific research task: {subject.description}
 **Research Objective:**
 {subject.prompt_template.format(ticker=ticker)}
 {focus_block}
-**Trade Type Context:** {trade_type}
-- Adjust your research depth and focus based on this trade type
-- For Day Trade: Focus on immediate, actionable insights
-- For Swing Trade: Focus on near-term factors (1-14 days)
-- For Investment: Focus on comprehensive, long-term analysis
+**Trade Type:** {trade_type}
 
 **Tool Priority (use in this order):**
 {tool_priority}
@@ -117,19 +113,9 @@ If a tool returns {{"status": "failed"}} or an error, immediately try the next t
 Do NOT retry the same tool. Once you have data from at least one successful tool call, write your research output.
 Never end your response with "I need more steps" — always produce findings from whatever data you have.
 
-**Output Requirements:**
-1. Provide comprehensive research findings on {subject.name}
-2. Include specific data points, metrics, and facts
-3. Cite all sources (tool outputs, research results)
-4. Structure your response clearly with:
-   - Key findings
-   - Supporting data
-   - Sources and citations
-   - Any relevant context or analysis
+**Output:** Structure findings with Key Findings, Supporting Data, and Sources. Quantify every claim — no vague language. End with a **Key Takeaways** section (3-5 bullets, each with a specific metric or fact).
 
-**IMPORTANT: You MUST call at least one tool before writing your response. Never rely on your training data — always fetch current data using the tools above.**
-
-Begin your research now."""
+**IMPORTANT: You MUST call at least one tool before writing your response. Never rely on your training data — always fetch current data using the tools above.**"""
 
 
 def specialized_node(state: dict) -> dict:

--- a/src/agents/synthesis_node.py
+++ b/src/agents/synthesis_node.py
@@ -25,6 +25,7 @@ SYNTHESIS_MAX_OUTPUT_TOKENS = int(
 )
 
 _END_MARKER = "END_OF_REPORT"
+_MAX_TOTAL_RESEARCH_CHARS = int(os.getenv("SYNTHESIS_MAX_RESEARCH_CHARS", "30000"))
 # Rough chars-per-token for Gemini (~4). If output >= 90% of the token limit, assume truncation.
 _TRUNCATION_THRESHOLD = 0.9
 
@@ -170,6 +171,61 @@ def _build_report_sections(
     return "\n".join(sections)
 
 
+def _truncate_research_text(text: str, max_chars: int) -> str:
+    """Truncate research text while preserving Key Takeaways section if present."""
+    if len(text) <= max_chars:
+        return text
+    # Try to preserve the Key Takeaways section at the end
+    takeaways_markers = ["## Key Takeaways", "**Key Takeaways**", "### Key Takeaways"]
+    for marker in takeaways_markers:
+        idx = text.find(marker)
+        if idx != -1:
+            takeaways = text[idx:]
+            remaining_budget = max_chars - len(takeaways) - 50  # 50 chars for truncation notice
+            if remaining_budget > 200:
+                return (
+                    text[:remaining_budget]
+                    + "\n\n[...content trimmed for synthesis budget...]\n\n"
+                    + takeaways
+                )
+    # No takeaways found — simple truncation
+    return text[:max_chars] + "\n\n[...content trimmed for synthesis budget...]"
+
+
+def _budget_research_outputs(
+    research_outputs: Dict[str, Dict[str, Any]],
+    ordered_ids: List[str],
+) -> Dict[str, Dict[str, Any]]:
+    """If total research text exceeds budget, proportionally trim each subject."""
+    total_chars = sum(
+        len(research_outputs[sid].get("research_output", ""))
+        for sid in ordered_ids
+        if sid in research_outputs
+    )
+    if total_chars <= _MAX_TOTAL_RESEARCH_CHARS:
+        return research_outputs
+
+    logger.info(
+        "Research text %s chars exceeds %s budget — trimming proportionally",
+        total_chars, _MAX_TOTAL_RESEARCH_CHARS,
+    )
+    max_per_subject = _MAX_TOTAL_RESEARCH_CHARS // len(ordered_ids)
+    trimmed = {}
+    for sid in ordered_ids:
+        if sid not in research_outputs:
+            continue
+        result = research_outputs[sid].copy()
+        output = result.get("research_output", "")
+        if len(output) > max_per_subject:
+            result["research_output"] = _truncate_research_text(output, max_per_subject)
+        trimmed[sid] = result
+    # Include any outputs not in ordered_ids
+    for sid, result in research_outputs.items():
+        if sid not in trimmed:
+            trimmed[sid] = result
+    return trimmed
+
+
 def _build_synthesis_prompt(
     ticker: str,
     trade_type: str,
@@ -186,6 +242,9 @@ def _build_synthesis_prompt(
     for sid in research_outputs:
         if sid not in ordered_ids:
             ordered_ids.append(sid)
+
+    # Apply per-subject truncation budget to prevent context rot
+    research_outputs = _budget_research_outputs(research_outputs, ordered_ids)
 
     sections_text = _build_report_sections(
         trade_type, ordered_ids, has_position=bool(plan.position_summary)
@@ -220,15 +279,15 @@ def _build_synthesis_prompt(
         ]
 
     prompt_parts += [
-        "**CRITICAL INSTRUCTIONS:**",
-        "",
+        "<instructions>",
         f"Specialized agents have researched {len(ordered_ids)} subjects on {ticker}.",
         "PRESERVE ALL DETAILS — do not summarize away specific numbers, facts, or examples.",
         "",
-        "**Report Structure to follow (in this order):**",
+        "Report Structure to follow (in this order):",
         sections_text,
+        "</instructions>",
         "",
-        "**Research Findings from Specialized Agents:**",
+        "<research_data>",
         "",
     ]
 
@@ -252,6 +311,8 @@ def _build_synthesis_prompt(
                 prompt_parts.append(f"{i}. {source}")
 
         prompt_parts += ["", "---", ""]
+
+    prompt_parts.append("</research_data>")
 
     if plan.position_summary:
         goal_line = ""

--- a/src/langchain_tools.py
+++ b/src/langchain_tools.py
@@ -65,7 +65,11 @@ def _make_mcp_handler(mcp_client: MCPClient, mcp_tool_name: str):
             return str(result)
         except Exception as e:
             return json.dumps(
-                {"error": f"Tool execution failed: {e}", "tool": mcp_tool_name},
+                {
+                    "error": f"Tool execution failed: {e}",
+                    "tool": mcp_tool_name,
+                    "suggestion": "Try a yfinance tool or nimble_web_search as an alternative data source.",
+                },
                 indent=2,
             )
 
@@ -172,7 +176,10 @@ def create_nimble_tools(nimble_client: NimbleClient) -> List[StructuredTool]:
             )
             return json.dumps(result, indent=2, default=str)
         except Exception as e:
-            return json.dumps({"error": f"Nimble search failed: {e}"})
+            return json.dumps({
+                "error": f"Nimble search failed: {e}",
+                "suggestion": "Try perplexity_research for a synthesized answer, or yfinance tools for financial data.",
+            })
 
     # --- nimble_extract ---
     class NimbleExtractArgs(BaseModel):
@@ -181,12 +188,23 @@ def create_nimble_tools(nimble_client: NimbleClient) -> List[StructuredTool]:
             default=False, description="Enable JS rendering for dynamic pages."
         )
 
+    MAX_EXTRACT_CHARS = 10000
+
     def nimble_extract(url: str, render: bool = False) -> str:
         try:
             result = nimble_client.extract(url, render=render)
-            return json.dumps(result, indent=2, default=str)
+            text = json.dumps(result, indent=2, default=str)
+            if len(text) > MAX_EXTRACT_CHARS:
+                return text[:MAX_EXTRACT_CHARS] + (
+                    "\n\n[Content truncated at 10,000 characters. "
+                    "Use nimble_web_search for a summary instead.]"
+                )
+            return text
         except Exception as e:
-            return json.dumps({"error": f"Nimble extract failed: {e}"})
+            return json.dumps({
+                "error": f"Nimble extract failed: {e}",
+                "suggestion": "Check the URL is valid. Try nimble_web_search to find an alternative source.",
+            })
 
     # --- perplexity_research ---
     class PerplexityArgs(BaseModel):
@@ -214,17 +232,20 @@ def create_nimble_tools(nimble_client: NimbleClient) -> List[StructuredTool]:
                 )
             return json.dumps({"research": result, "status": "success"})
         except Exception as e:
-            return json.dumps(
-                {"status": "failed", "error": f"perplexity_research failed: {e}"}
-            )
+            return json.dumps({
+                "status": "failed",
+                "error": f"perplexity_research failed: {e}",
+                "suggestion": "Try nimble_web_search for a direct web search, or yfinance tools for financial data.",
+            })
 
     return [
         StructuredTool.from_function(
             func=nimble_web_search,
             name="nimble_web_search",
             description=(
-                "Search the web in real-time using Nimble's infrastructure. "
-                "Use for recent news, analyst reports, company announcements, industry trends."
+                "Search the web for specific facts: news articles, press releases, analyst reports, "
+                "SEC filings, financial data, company announcements. Returns raw search results "
+                "you must analyze yourself. Use this for any factual lookup."
             ),
             args_schema=NimbleSearchArgs,
         ),
@@ -232,8 +253,9 @@ def create_nimble_tools(nimble_client: NimbleClient) -> List[StructuredTool]:
             func=nimble_extract,
             name="nimble_extract",
             description=(
-                "Extract and parse content from a specific URL using Nimble's browser infrastructure. "
-                "Use for press releases, SEC filings, earnings transcripts, IR pages."
+                "Extract and parse full page content from a specific URL. "
+                "Use when you have a URL from search results that you need to read in full "
+                "(e.g., a press release, earnings transcript, SEC filing page)."
             ),
             args_schema=NimbleExtractArgs,
         ),
@@ -241,8 +263,10 @@ def create_nimble_tools(nimble_client: NimbleClient) -> List[StructuredTool]:
             func=perplexity_research,
             name="perplexity_research",
             description=(
-                "Perform real-time web research using Perplexity (via Nimble). "
-                "Use for recent news, market analysis, company developments, industry trends."
+                "Get a synthesized analytical answer to a complex research question. "
+                "Use ONLY when you need expert-level synthesis across multiple sources — "
+                "e.g. 'What is the consensus view on X competitive moat?' "
+                "Do NOT use for simple fact-finding (use nimble_web_search instead)."
             ),
             args_schema=PerplexityArgs,
         ),
@@ -353,9 +377,10 @@ def create_yfinance_tools() -> List[StructuredTool]:
             }
             return json.dumps(_sanitize_nan(result), indent=2, default=str)
         except Exception as e:
-            return json.dumps(
-                {"error": f"yfinance_fundamentals failed for {symbol}: {e}"}
-            )
+            return json.dumps({
+                "error": f"yfinance_fundamentals failed for {symbol}: {e}",
+                "suggestion": "Try yfinance_analyst for a lighter data pull, or nimble_web_search to find fundamentals online.",
+            })
 
     # --- yfinance_analyst ---
     def yfinance_analyst(symbol: str) -> str:
@@ -385,7 +410,10 @@ def create_yfinance_tools() -> List[StructuredTool]:
             }
             return json.dumps(_sanitize_nan(result), indent=2, default=str)
         except Exception as e:
-            return json.dumps({"error": f"yfinance_analyst failed for {symbol}: {e}"})
+            return json.dumps({
+                "error": f"yfinance_analyst failed for {symbol}: {e}",
+                "suggestion": "Try yfinance_fundamentals for broader data, or nimble_web_search for analyst coverage.",
+            })
 
     # --- yfinance_ownership ---
     def yfinance_ownership(symbol: str) -> str:
@@ -411,7 +439,10 @@ def create_yfinance_tools() -> List[StructuredTool]:
             }
             return json.dumps(_sanitize_nan(result), indent=2, default=str)
         except Exception as e:
-            return json.dumps({"error": f"yfinance_ownership failed for {symbol}: {e}"})
+            return json.dumps({
+                "error": f"yfinance_ownership failed for {symbol}: {e}",
+                "suggestion": "Try nimble_web_search for institutional holder data, or sec_edgar_filings for insider filings.",
+            })
 
     # --- yfinance_options ---
     def yfinance_options(symbol: str) -> str:
@@ -464,7 +495,10 @@ def create_yfinance_tools() -> List[StructuredTool]:
             }
             return json.dumps(_sanitize_nan(result), indent=2, default=str)
         except Exception as e:
-            return json.dumps({"error": f"yfinance_options failed for {symbol}: {e}"})
+            return json.dumps({
+                "error": f"yfinance_options failed for {symbol}: {e}",
+                "suggestion": "Try nimble_web_search for options market data or perplexity_research for technical analysis.",
+            })
 
     return [
         StructuredTool.from_function(
@@ -553,7 +587,10 @@ def create_sec_edgar_tool() -> StructuredTool:
                 })
             return json.dumps(results, indent=2, default=str)
         except Exception as e:
-            return json.dumps({"error": f"SEC EDGAR lookup failed: {e}"})
+            return json.dumps({
+                "error": f"SEC EDGAR lookup failed: {e}",
+                "suggestion": "Try nimble_web_search for SEC filings, or yfinance_fundamentals for financial statement data.",
+            })
 
     return StructuredTool.from_function(
         func=sec_edgar_filings,

--- a/src/research_graph.py
+++ b/src/research_graph.py
@@ -57,12 +57,14 @@ class ResearchState(TypedDict):
     actual_input_tokens: Annotated[int, operator.add]  # summed across all nodes
     actual_output_tokens: Annotated[int, operator.add]  # summed across all nodes
     actual_cost_usd: Optional[float]  # computed in storage_node
+    language: Optional[str]  # user language preference ('en' or 'he')
 
 
 _MAX_SUBJECTS = int(os.getenv("MAX_RESEARCH_SUBJECTS", "8"))
 _MIN_OUTPUT_CHARS = int(os.getenv("QUALITY_GATE_MIN_OUTPUT_CHARS", "200"))
 _URL_RE = re.compile(r"https?://[^\s<>\"{}|\\^`\[\]]+")
 _MAX_ABORT_DETAIL_CHARS = 600
+_NUMBER_RE = re.compile(r"\d+\.?\d*%?")  # matches numbers/percentages in text
 
 
 def _subject_failure_reason(subject_id: str, result: Dict[str, Any]) -> str:
@@ -89,8 +91,9 @@ def _fan_out(state: ResearchState) -> List[Send]:
     ):
         trimmed = subject_ids[:effective_subject_count]
         dropped = subject_ids[effective_subject_count:]
-        print(
-            f"[FanOut] Budget trimmed subjects from {len(subject_ids)} → {effective_subject_count}. Dropped: {dropped}"
+        logger.info(
+            "Budget trimmed subjects from %s to %s. Dropped: %s",
+            len(subject_ids), effective_subject_count, dropped,
         )
         subject_ids = trimmed
 
@@ -210,19 +213,30 @@ def quality_gate_node(state: ResearchState) -> dict:
     failed = []
     clean_outputs = {}
     for sid, result in research_outputs.items():
+        output = result.get("research_output", "")
         if result.get("error"):
             failed.append(sid)
-        elif len(result.get("research_output", "")) < _MIN_OUTPUT_CHARS:
-            char_count = len(result.get("research_output", ""))
+        elif len(output) < _MIN_OUTPUT_CHARS:
             logger.warning(
                 "%s: output too short (%s chars) — treating as failure",
+                sid, len(output),
+            )
+            failed.append(sid)
+        elif not _NUMBER_RE.search(output):
+            logger.warning(
+                "%s: output contains no data points (numbers/percentages) — treating as failure",
                 sid,
-                char_count,
+            )
+            failed.append(sid)
+        elif ticker.upper() not in output.upper():
+            logger.warning(
+                "%s: output does not reference ticker %s — treating as failure",
+                sid, ticker,
             )
             failed.append(sid)
         else:
             urls = list(
-                dict.fromkeys(_URL_RE.findall(result.get("research_output", "")))
+                dict.fromkeys(_URL_RE.findall(output))
             )
             clean_outputs[sid] = {**result, "sources": urls}
 
@@ -315,6 +329,7 @@ def run_research(
     parent_config: Optional[Dict[str, Any]] = None,
     username: Optional[str] = None,
     progress_fn: Optional[Any] = None,
+    language: Optional[str] = None,
 ) -> Dict[str, Any]:
     """
     Execute the full research pipeline.
@@ -347,6 +362,7 @@ def run_research(
         "actual_input_tokens": 0,
         "actual_output_tokens": 0,
         "actual_cost_usd": None,
+        "language": language,
     }
 
     run_name = (

--- a/src/research_prompt.py
+++ b/src/research_prompt.py
@@ -2,144 +2,7 @@
 Research prompt templates and system instructions for the stock research agent.
 """
 
-from src.date_utils import get_datetime_context_string
-
-
-def get_system_instructions(ticker: str, trade_type: str) -> str:
-    """
-    Generate system instructions for the agent based on ticker and trade type.
-
-    Args:
-        ticker: Stock ticker symbol
-        trade_type: Type of trade (Day Trade, Swing Trade, or Investment)
-
-    Returns:
-        System instructions string for the agent
-    """
-
-    # Get current date/time context
-    datetime_context = get_datetime_context_string()
-
-    base_instructions = f"""You are a hedge fund equity research analyst specializing in {trade_type} analysis. Your mission is to perform a fundamental research report on the stock with ticker {ticker}.
-
-{datetime_context}
-
-Adjust research depth, time horizon, and key metrics based on the trade type:
-
-- Day Trade: Focus on intraday catalysts, news, liquidity, and very short-term drivers.
-- Swing Trade (1–14 days): Focus on near-term earnings, revisions, sector momentum, and event-driven catalysts.
-- Investment (3+ months): Perform deep fundamental research, long-term growth, valuation, and risk analysis.
-
-Use a clear structure:
-1. Company overview
-2. Recent developments
-3. Financial snapshot (with trend analysis)
-4. Valuation and peers
-5. Catalysts and risks
-6. Thesis summary
-7. Actionable view tailored to {trade_type}
-
-## Research Tools
-
-You have three complementary tool types:
-
-- **Alpha Vantage MCP** (structured data): fundamentals, financial statements, earnings, balance sheet, cash flow.
-- **Nimble** (raw web): `nimble_web_search` for web searches, `nimble_extract` to read a specific URL.
-- **Perplexity** (synthesized answers): use sparingly for complex analytical questions only.
-
-Tool strategy:
-- Use Alpha Vantage first for core financials and hard numbers.
-- Use nimble_web_search for any factual web research — news, announcements, filings, competitive moves.
-- Use nimble_extract when you have a specific URL to read in full.
-- Use Perplexity only when a synthesized expert answer adds value that raw search results cannot.
-
-Key Alpha Vantage tools:
-- overview, income_statement, balance_sheet, cash_flow, earnings, news_sentiment
-
-When using financial statement tools, analyze YoY and QoQ trends for revenue, margins, cash flow, and balance sheet strength. Summarize key trends rather than listing every data point.
-
-Before generating the final report:
-- Ensure you have used structured financial data and real-time web research where relevant.
-- Ask a small number of clarifying questions if the user’s goals or constraints are unclear.
-
-Final output:
-- Deliver a concise, structured report tailored to {trade_type}, highlighting the most important drivers, risks, and actionable insights.
-
-[TICKER]: {ticker}
-[type_of_trade]: {trade_type}
-"""
-
-    return base_instructions
-
-
-def get_specialized_agent_instructions(
-    subject_id: str, ticker: str, trade_type: str
-) -> str:
-    """
-    Generate specialized system instructions for a research subject agent.
-
-    Args:
-        subject_id: Research subject ID
-        ticker: Stock ticker symbol
-        trade_type: Type of trade
-
-    Returns:
-        System instructions string for the specialized agent
-    """
-    from src.research_subjects import get_research_subject_by_id
-
-    subject = get_research_subject_by_id(subject_id)
-
-    # Get current date/time context
-    datetime_context = get_datetime_context_string()
-
-    instructions = f"""You are a specialized research analyst focusing on {subject.name} for {ticker}.
-
-{datetime_context}
-
-Your specific research task: {subject.description}
-
-**Research Objective:**
-{subject.prompt_template.format(ticker=ticker)}
-
-**Trade Type Context:** {trade_type}
-- For Day Trade: Focus on immediate, actionable insights.
-- For Swing Trade: Focus on near-term (1–14 day) drivers.
-- For Investment: Focus on comprehensive, long-term fundamentals.
-
-**Available Tools and When to Use Each:**
-
-1. **Alpha Vantage MCP** — structured financial data only.
-   Use for: income statements, balance sheets, cash flow, earnings, company overview, news sentiment scores.
-
-2. **nimble_web_search** — your primary tool for all web research.
-   Use for: product announcements, press releases, leadership changes, competitive moves, partnerships, regulatory filings, industry news, analyst commentary, pricing changes, and any factual company or market information you need to find yourself.
-   You are the analyst — search, read the results, and form your own conclusions.
-   Prefer `topic="news"` for recent events. Use `time_range="month"` or `time_range="week"` for recency.
-
-3. **nimble_extract** — read a specific page in full.
-   Use when a search result returns a URL that you need to read completely (e.g., a press release, earnings transcript, SEC filing page, investor relations announcement).
-
-4. **perplexity_research** — use sparingly, only when you need a synthesized expert answer.
-   Reserve for: complex multi-source analytical questions where synthesis adds value over raw results (e.g., "What is the consensus view on X's competitive moat?"). Do NOT use it for facts you can find directly with nimble_web_search.
-
-**Tool priority:** Alpha Vantage → nimble_web_search → nimble_extract → perplexity_research (last resort).
-
-**Output Format (required):**
-- Use markdown headers for each analytical section
-- Lead every section with a 1-sentence "bottom line" finding, then support with data
-- Quantify every claim — avoid vague language ("growing well" → "revenue +23% YoY")
-- Flag any data gaps or conflicting signals explicitly
-- End with a **Key Takeaways** section: 3–5 bullets, each containing a specific metric or fact
-
-**Scope constraint:**
-- Focus exclusively on {subject.name}
-- Do not duplicate findings that belong to other research subjects
-- Cite the specific tool or source for each data point
-
-Begin your research now."""
-
-    return instructions
+from date_utils import get_datetime_context_string
 
 
 def get_orchestration_instructions(ticker: str, trade_type: str) -> str:
@@ -167,7 +30,7 @@ def get_orchestration_instructions(ticker: str, trade_type: str) -> str:
 
 **Trade Type Context:**
 - Day Trade: Ask about immediate catalysts and very short-term focus.
-- Swing Trade: Ask about 1–14 day horizon, events, and sector momentum.
+- Swing Trade: Ask about 1-14 day horizon, events, and sector momentum.
 - Investment: Ask about long-term goals, risk tolerance, and thesis focus.
 
 **Questions to Consider:**
@@ -177,19 +40,19 @@ def get_orchestration_instructions(ticker: str, trade_type: str) -> str:
 - Any specific metrics or factors to emphasize.
 
 **Available Tools:**
-1. `ask_user_questions(questions)` — Call this ONCE at the start of the session to gather user context.
-   - Pass 1–3 multiple-choice questions as a JSON array.
+1. `ask_user_questions(questions)` -- Call this ONCE at the start of the session to gather user context.
+   - Pass 1-3 multiple-choice questions as a JSON array.
    - Each item: {{"question": "...", "options": ["A", "B", "C"]}}
    - Call this BEFORE `generate_report`. Do not skip it.
-   - After calling it, stop and wait — do not call `generate_report` in the same turn.
+   - After calling it, stop and wait -- do not call `generate_report` in the same turn.
 
-2. `generate_report()` — Call this after the user has answered your questions.
+2. `generate_report()` -- Call this after the user has answered your questions.
    - Only call once you have the user's answers in the conversation.
    - After calling, tell the user that research has started.
 
 **Guidelines:**
-- Always start a new research session by calling `ask_user_questions` with 1–3 focused questions.
-- Tailor your questions to {trade_type}: Day Trade → immediate catalysts/risk; Swing Trade → event horizon/sector momentum; Investment → time horizon/thesis focus/risk tolerance.
+- Always start a new research session by calling `ask_user_questions` with 1-3 focused questions.
+- Tailor your questions to {trade_type}: Day Trade -> immediate catalysts/risk; Swing Trade -> event horizon/sector momentum; Investment -> time horizon/thesis focus/risk tolerance.
 - Do NOT generate the report on the first turn. Ask questions first.
 - After the user answers, call `generate_report` without waiting for more input.
 
@@ -197,57 +60,3 @@ def get_orchestration_instructions(ticker: str, trade_type: str) -> str:
 [TYPE_OF_TRADE]: {trade_type}"""
 
     return instructions
-
-
-def get_followup_question_prompt(trade_type: str, context: str = "") -> str:
-    """
-    Generate a prompt to help the agent determine if follow-up questions are needed.
-
-    Args:
-        trade_type: Type of trade
-        context: Additional context from the conversation
-
-    Returns:
-        Prompt for follow-up question generation
-    """
-
-    trade_specific_guidance = {
-        "Day Trade": """
-        Consider asking about:
-        - Specific time horizon for the day trade (morning, afternoon, full day)
-        - Key catalysts or events to watch
-        - Risk tolerance for intraday moves
-        - Preferred entry/exit strategies
-        - Any specific sectors or market conditions to consider
-        """,
-        "Swing Trade": """
-        Consider asking about:
-        - Exact holding period (1-3 days, 1 week, 2 weeks)
-        - Key events or earnings dates to watch
-        - Sector momentum preferences
-        - Risk/reward expectations
-        - Any specific technical or fundamental triggers
-        """,
-        "Investment": """
-        Consider asking about:
-        - Investment time horizon (3 months, 6 months, 1 year, longer)
-        - Investment thesis focus (growth, value, dividend, etc.)
-        - Risk factors to emphasize
-        - Valuation methodology preferences
-        - Competitive analysis depth
-        - Management quality assessment needs
-        """,
-    }
-
-    guidance = trade_specific_guidance.get(trade_type, "")
-
-    prompt = f"""Based on the trade type ({trade_type}) and current context, determine if you need to ask follow-up questions before proceeding with data collection and report generation.
-
-{guidance}
-
-If you need clarification on any of these areas, ask 1-3 concise, specific questions. Otherwise, proceed with gathering data using Alpha Vantage MCP tools, Nimble web search, and Perplexity where synthesis is needed, then generate the research report.
-
-Context: {context}
-"""
-
-    return prompt

--- a/tests/test_agent_pipeline_improvements.py
+++ b/tests/test_agent_pipeline_improvements.py
@@ -1,0 +1,495 @@
+"""
+Tests for agent pipeline improvements:
+  - Quality gate heuristics (data points, ticker reference)
+  - Synthesis input budget (truncation)
+  - Actionable error messages
+  - nimble_extract response truncation
+  - Stale prompt cleanup
+
+Run: python -m pytest tests/test_agent_pipeline_improvements.py -v
+"""
+
+import json
+import re
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Quality Gate Heuristics
+# ---------------------------------------------------------------------------
+
+class TestQualityGateHeuristics:
+    """Test the enhanced quality gate in research_graph.py."""
+
+    def _run_gate(self, research_outputs, ticker="AAPL"):
+        """Run quality_gate_node with minimal state."""
+        from research_graph import quality_gate_node
+
+        state = {
+            "research_outputs": research_outputs,
+            "ticker": ticker,
+            "emitter": None,
+        }
+        return quality_gate_node(state)
+
+    def test_good_output_passes(self):
+        outputs = {
+            "valuation_metrics": {
+                "subject_id": "valuation_metrics",
+                "subject_name": "Valuation Metrics",
+                "research_output": (
+                    "AAPL trades at a P/E of 28.5x, above the sector average of 22.1x. "
+                    "Revenue grew 8.2% YoY to $94.9B in the most recent quarter. "
+                    "The forward P/E is 25.3x based on analyst consensus estimates. "
+                    "Free cash flow margin is 26.4%, supporting a $110B buyback program. "
+                    "Enterprise value to EBITDA stands at 21.8x."
+                ),
+                "sources": [],
+            }
+        }
+        result = self._run_gate(outputs)
+        assert "valuation_metrics" in result["research_outputs"]
+        assert result["failed_subjects"] == []
+
+    def test_output_too_short_fails(self):
+        outputs = {
+            "growth_drivers": {
+                "subject_id": "growth_drivers",
+                "subject_name": "Growth Drivers",
+                "research_output": "Short.",
+                "sources": [],
+            }
+        }
+        result = self._run_gate(outputs)
+        assert "growth_drivers" in result["failed_subjects"]
+
+    def test_output_with_error_key_fails(self):
+        outputs = {
+            "risk_factors": {
+                "subject_id": "risk_factors",
+                "subject_name": "Risk Factors",
+                "research_output": "Some content about AAPL with 10% risk",
+                "error": "rate limit exceeded",
+                "sources": [],
+            }
+        }
+        result = self._run_gate(outputs)
+        assert "risk_factors" in result["failed_subjects"]
+
+    def test_no_data_points_fails(self):
+        """Output with no numbers/percentages should fail."""
+        outputs = {
+            "financial_health": {
+                "subject_id": "financial_health",
+                "subject_name": "Financial Health",
+                "research_output": (
+                    "AAPL has strong financial health with excellent cash reserves. "
+                    "The company maintains a solid balance sheet and generates "
+                    "significant free cash flow. Revenue continues to grow steadily. "
+                    "Management has been prudent with capital allocation."
+                ),
+                "sources": [],
+            }
+        }
+        result = self._run_gate(outputs)
+        assert "financial_health" in result["failed_subjects"]
+
+    def test_no_ticker_reference_fails(self):
+        """Output that never mentions the ticker should fail."""
+        outputs = {
+            "sector_macro": {
+                "subject_id": "sector_macro",
+                "subject_name": "Sector & Macro",
+                "research_output": (
+                    "The technology sector saw 15.3% growth in Q1 2026. "
+                    "Interest rates remain at 4.5% and inflation is at 2.8%. "
+                    "Consumer spending increased 3.2% year over year."
+                ),
+                "sources": [],
+            }
+        }
+        result = self._run_gate(outputs, ticker="AAPL")
+        assert "sector_macro" in result["failed_subjects"]
+
+    def test_ticker_check_is_case_insensitive(self):
+        """Ticker check should match 'aapl', 'AAPL', 'Aapl'."""
+        outputs = {
+            "valuation_metrics": {
+                "subject_id": "valuation_metrics",
+                "subject_name": "Valuation",
+                "research_output": (
+                    "aapl is currently trading at a P/E ratio of 28.5x, which is above the "
+                    "tech sector average. Revenue grew 8.2% year-over-year to reach $94.9B. "
+                    "Operating margin expanded 150 basis points to 30.1%. "
+                    "The forward P/E stands at 25.3x based on consensus estimates."
+                ),
+                "sources": [],
+            }
+        }
+        result = self._run_gate(outputs, ticker="AAPL")
+        assert "valuation_metrics" in result["research_outputs"]
+        assert result["failed_subjects"] == []
+
+    def test_mixed_pass_and_fail(self):
+        """One good output and one bad should partial-pass."""
+        outputs = {
+            "good": {
+                "subject_id": "good",
+                "subject_name": "Good Subject",
+                "research_output": (
+                    "TSLA revenue grew 12.5% to $25.2B in the latest quarter. "
+                    "Gross margin was 18.2%, down from 19.5% in the prior quarter. "
+                    "The company delivered 495,000 vehicles in Q1 2026, up 8% YoY. "
+                    "Energy storage deployments reached 12.4 GWh, a record quarter."
+                ),
+                "sources": [],
+            },
+            "bad_no_numbers": {
+                "subject_id": "bad_no_numbers",
+                "subject_name": "Bad Subject",
+                "research_output": (
+                    "TSLA is doing well with strong growth and good market position "
+                    "across all segments. The outlook remains positive for the future. "
+                    "Management continues to execute on their strategy effectively. "
+                    "The competitive landscape favors continued expansion globally."
+                ),
+                "sources": [],
+            },
+        }
+        result = self._run_gate(outputs, ticker="TSLA")
+        assert "good" in result["research_outputs"]
+        assert "bad_no_numbers" in result["failed_subjects"]
+
+    def test_abort_when_majority_fail(self):
+        """When >50% subjects fail, gate should set report_text (abort)."""
+        outputs = {
+            "fail1": {
+                "subject_id": "fail1",
+                "subject_name": "Fail 1",
+                "research_output": "short",
+                "sources": [],
+            },
+            "fail2": {
+                "subject_id": "fail2",
+                "subject_name": "Fail 2",
+                "research_output": "also short",
+                "sources": [],
+            },
+            "pass1": {
+                "subject_id": "pass1",
+                "subject_name": "Pass 1",
+                "research_output": (
+                    "AAPL has revenue of $94.9B with 8.2% growth and a P/E of 28.5x. "
+                    "Free cash flow is $26B annually."
+                ),
+                "sources": [],
+            },
+        }
+        result = self._run_gate(outputs, ticker="AAPL")
+        assert result.get("report_text"), "Gate should abort with a report_text message"
+        assert "failed" in result["report_text"].lower()
+
+
+# ---------------------------------------------------------------------------
+# Synthesis Input Budget
+# ---------------------------------------------------------------------------
+
+class TestSynthesisBudget:
+    """Test _truncate_research_text and _budget_research_outputs."""
+
+    def test_truncate_short_text_unchanged(self):
+        from agents.synthesis_node import _truncate_research_text
+
+        text = "Short text with data."
+        assert _truncate_research_text(text, 1000) == text
+
+    def test_truncate_long_text_cuts(self):
+        from agents.synthesis_node import _truncate_research_text
+
+        text = "x" * 5000
+        result = _truncate_research_text(text, 1000)
+        assert len(result) < 1100  # 1000 + truncation notice
+        assert "trimmed" in result.lower()
+
+    def test_truncate_preserves_key_takeaways(self):
+        from agents.synthesis_node import _truncate_research_text
+
+        body = "A" * 3000
+        takeaways = "## Key Takeaways\n- Revenue grew 15%\n- Margin expanded 200bps"
+        text = body + "\n\n" + takeaways
+        result = _truncate_research_text(text, 1000)
+        assert "Key Takeaways" in result
+        assert "Revenue grew 15%" in result
+
+    def test_truncate_preserves_bold_takeaways(self):
+        from agents.synthesis_node import _truncate_research_text
+
+        body = "B" * 3000
+        takeaways = "**Key Takeaways**\n- EPS beat by 12%\n- Guidance raised"
+        text = body + "\n\n" + takeaways
+        result = _truncate_research_text(text, 1000)
+        assert "Key Takeaways" in result
+        assert "EPS beat" in result
+
+    def test_budget_under_limit_no_change(self):
+        from agents.synthesis_node import _budget_research_outputs
+
+        outputs = {
+            "sub1": {"research_output": "Short " * 50},
+            "sub2": {"research_output": "Also short " * 50},
+        }
+        result = _budget_research_outputs(outputs, ["sub1", "sub2"])
+        assert result["sub1"]["research_output"] == outputs["sub1"]["research_output"]
+        assert result["sub2"]["research_output"] == outputs["sub2"]["research_output"]
+
+    def test_budget_over_limit_trims(self):
+        from agents.synthesis_node import _budget_research_outputs, _MAX_TOTAL_RESEARCH_CHARS
+
+        # Create outputs that exceed the budget
+        long_text = "AAPL revenue grew 15.3% " * 2000  # ~48K chars
+        outputs = {
+            "sub1": {"research_output": long_text},
+            "sub2": {"research_output": long_text},
+        }
+        result = _budget_research_outputs(outputs, ["sub1", "sub2"])
+        total = sum(len(r["research_output"]) for r in result.values())
+        # Total should be roughly within budget (with some overhead for truncation notices)
+        assert total < _MAX_TOTAL_RESEARCH_CHARS * 1.1
+
+    def test_budget_preserves_unordered_subjects(self):
+        """Subjects not in ordered_ids should still be in the output."""
+        from agents.synthesis_node import _budget_research_outputs
+
+        outputs = {
+            "sub1": {"research_output": "text1"},
+            "extra": {"research_output": "extra text"},
+        }
+        result = _budget_research_outputs(outputs, ["sub1"])
+        assert "extra" in result
+
+
+# ---------------------------------------------------------------------------
+# Actionable Error Messages
+# ---------------------------------------------------------------------------
+
+class TestActionableErrors:
+    """Verify all tool error responses include a suggestion field."""
+
+    def test_mcp_handler_error_has_suggestion(self):
+        """MCP handler errors should include a suggestion."""
+        from langchain_tools import _make_mcp_handler
+
+        class FakeMCP:
+            pass
+
+        # _make_mcp_handler will fail when called since FakeMCP has no methods,
+        # which is exactly what we want to test the error path
+        handler = _make_mcp_handler(FakeMCP(), "FAKE_TOOL")
+        result = json.loads(handler(symbol="AAPL"))
+        assert "error" in result
+        assert "suggestion" in result
+
+    def test_yfinance_fundamentals_error_has_suggestion(self):
+        """yfinance_fundamentals error should suggest alternatives."""
+        from langchain_tools import create_yfinance_tools
+
+        tools = create_yfinance_tools()
+        fundamentals = next(t for t in tools if t.name == "yfinance_fundamentals")
+        # Use an invalid symbol to trigger an error in the handler
+        result = json.loads(fundamentals.invoke({"symbol": ""}))
+        # Even if it succeeds with empty symbol, check the structure
+        if "error" in result:
+            assert "suggestion" in result
+
+    def test_sec_edgar_error_has_suggestion(self):
+        """sec_edgar error should include suggestion."""
+        from langchain_tools import create_sec_edgar_tool
+
+        tool = create_sec_edgar_tool()
+        result = json.loads(tool.invoke({"symbol": "ZZZNOTREAL999"}))
+        # If no filings found, it returns a message not an error
+        # But if it errors, should have suggestion
+        if "error" in result:
+            assert "suggestion" in result
+
+
+# ---------------------------------------------------------------------------
+# nimble_extract Truncation
+# ---------------------------------------------------------------------------
+
+class TestNimbleExtractTruncation:
+    """Test that nimble_extract truncates large responses."""
+
+    def test_truncation_logic_directly(self):
+        """Verify the truncation constant and logic exist."""
+        # We can't easily call nimble_extract without a real client,
+        # but we can verify the constant is set
+        import langchain_tools
+        # The MAX_EXTRACT_CHARS is defined inside create_nimble_tools,
+        # so we verify the truncation pattern by reading the source
+        import inspect
+        source = inspect.getsource(langchain_tools.create_nimble_tools)
+        assert "MAX_EXTRACT_CHARS" in source
+        assert "10000" in source or "10_000" in source
+        assert "truncated" in source.lower()
+
+
+# ---------------------------------------------------------------------------
+# Stale Prompt Cleanup
+# ---------------------------------------------------------------------------
+
+class TestResearchPromptCleanup:
+    """Verify stale functions were removed and import is fixed."""
+
+    def test_only_orchestration_instructions_exists(self):
+        import research_prompt
+        assert hasattr(research_prompt, "get_orchestration_instructions")
+        assert not hasattr(research_prompt, "get_system_instructions")
+        assert not hasattr(research_prompt, "get_specialized_agent_instructions")
+        assert not hasattr(research_prompt, "get_followup_question_prompt")
+
+    def test_orchestration_instructions_returns_string(self):
+        from research_prompt import get_orchestration_instructions
+        result = get_orchestration_instructions("AAPL", "Investment")
+        assert isinstance(result, str)
+        assert "AAPL" in result
+        assert "Investment" in result
+
+    def test_no_src_prefix_import(self):
+        """Verify the file uses 'from date_utils' not 'from src.date_utils'."""
+        import inspect
+        import research_prompt
+        source = inspect.getsource(research_prompt)
+        assert "from src.date_utils" not in source
+        assert "from date_utils" in source
+
+
+# ---------------------------------------------------------------------------
+# Specialized Prompt Trimming
+# ---------------------------------------------------------------------------
+
+class TestSpecializedPromptTrimming:
+    """Verify the specialized prompt is leaner."""
+
+    def test_no_begin_research_now(self):
+        from agents.specialized_node import _get_instructions
+        from research_subjects import get_research_subjects_for_trade_type
+
+        subjects = get_research_subjects_for_trade_type("Investment")
+        instructions = _get_instructions(subjects[0], "AAPL", "Investment")
+        assert "Begin your research now" not in instructions
+
+    def test_has_key_takeaways_requirement(self):
+        from agents.specialized_node import _get_instructions
+        from research_subjects import get_research_subjects_for_trade_type
+
+        subjects = get_research_subjects_for_trade_type("Investment")
+        instructions = _get_instructions(subjects[0], "AAPL", "Investment")
+        assert "Key Takeaways" in instructions
+
+    def test_no_verbose_trade_type_bullets(self):
+        """The old 3-bullet trade type expansion should be gone."""
+        from agents.specialized_node import _get_instructions
+        from research_subjects import get_research_subjects_for_trade_type
+
+        subjects = get_research_subjects_for_trade_type("Day Trade")
+        instructions = _get_instructions(subjects[0], "AAPL", "Day Trade")
+        assert "Adjust your research depth and focus" not in instructions
+
+
+# ---------------------------------------------------------------------------
+# Planner Examples
+# ---------------------------------------------------------------------------
+
+class TestPlannerExamples:
+    """Verify planner prompt contains examples."""
+
+    def test_planner_prompt_has_examples(self):
+        from agents.planner_node import _build_system_prompt
+        from research_subjects import get_research_subjects_for_trade_type
+
+        eligible = get_research_subjects_for_trade_type("Investment")
+        prompt = _build_system_prompt("AAPL", "Investment", eligible)
+        assert "<examples>" in prompt
+        assert "</examples>" in prompt
+        assert "Day Trade" in prompt  # Day Trade example
+        assert "TSLA" in prompt or "AAPL" in prompt  # example ticker
+
+    def test_planner_prompt_has_two_examples(self):
+        from agents.planner_node import _build_system_prompt
+        from research_subjects import get_research_subjects_for_trade_type
+
+        eligible = get_research_subjects_for_trade_type("Investment")
+        prompt = _build_system_prompt("MSFT", "Investment", eligible)
+        # Should have "Example 1" and "Example 2"
+        assert "Example 1" in prompt
+        assert "Example 2" in prompt
+
+
+# ---------------------------------------------------------------------------
+# XML Tags in Synthesis
+# ---------------------------------------------------------------------------
+
+class TestSynthesisXMLTags:
+    """Verify synthesis prompt uses XML structural tags."""
+
+    def test_synthesis_prompt_has_xml_tags(self):
+        from agents.synthesis_node import _build_synthesis_prompt
+        from research_plan import ResearchPlan
+
+        plan = ResearchPlan(
+            ticker="AAPL",
+            trade_type="Investment",
+            selected_subject_ids=["valuation_metrics"],
+            subject_focus={"valuation_metrics": ""},
+            trade_context="Testing synthesis",
+            planner_reasoning="test",
+        )
+        outputs = {
+            "valuation_metrics": {
+                "subject_name": "Valuation Metrics",
+                "research_output": "AAPL P/E is 28.5x with 8.2% revenue growth.",
+                "focus_hint": "",
+                "sources": [],
+            }
+        }
+        prompt = _build_synthesis_prompt("AAPL", "Investment", outputs, plan)
+        assert "<instructions>" in prompt
+        assert "</instructions>" in prompt
+        assert "<research_data>" in prompt
+        assert "</research_data>" in prompt
+
+
+# ---------------------------------------------------------------------------
+# Tool Description Differentiation
+# ---------------------------------------------------------------------------
+
+class TestToolDescriptions:
+    """Verify nimble_web_search and perplexity_research have distinct descriptions."""
+
+    def test_descriptions_are_different(self):
+        from langchain_tools import create_nimble_tools
+        from nimble_client import NimbleClient
+
+        # Create a mock client just to get tool definitions
+        class FakeNimble:
+            pass
+
+        try:
+            tools = create_nimble_tools(FakeNimble())
+        except Exception:
+            pytest.skip("Could not create nimble tools with fake client")
+
+        search_tool = next((t for t in tools if t.name == "nimble_web_search"), None)
+        perplexity_tool = next((t for t in tools if t.name == "perplexity_research"), None)
+
+        assert search_tool is not None
+        assert perplexity_tool is not None
+
+        # Key differentiation: search = "specific facts", perplexity = "synthesized"
+        assert "specific facts" in search_tool.description.lower() or "raw" in search_tool.description.lower()
+        assert "synthesized" in perplexity_tool.description.lower() or "synthesis" in perplexity_tool.description.lower()
+
+        # They should NOT share the same generic description
+        assert search_tool.description != perplexity_tool.description

--- a/tests/test_integration_pipeline.py
+++ b/tests/test_integration_pipeline.py
@@ -1,0 +1,325 @@
+"""
+Integration tests -- real API calls to verify the full research pipeline
+after the agent architecture improvements.
+
+Run with: python -m pytest tests/test_integration_pipeline.py --integration -v -s
+
+Requires:
+  - GEMINI_API_KEY in .env
+  - Network access to Google AI, Yahoo Finance, SEC EDGAR
+"""
+
+import json
+import logging
+import os
+import time
+
+import pytest
+from dotenv import load_dotenv
+
+load_dotenv()
+
+pytestmark = pytest.mark.integration
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Planner -- real LLM call
+# ---------------------------------------------------------------------------
+
+class TestPlannerLive:
+    """Test that the planner produces valid JSON with the new examples in prompt."""
+
+    def test_planner_day_trade(self):
+        from agents.planner_node import planner_node
+        from research_subjects import get_research_subjects_for_trade_type
+
+        state = {
+            "ticker": "NVDA",
+            "trade_type": "Day Trade",
+            "conversation_context": "Looking at NVDA for a quick intraday play after earnings.",
+            "emitter": None,
+            "progress_fn": None,
+            "user_selected_subjects": None,
+            "spend_budget_usd": None,
+        }
+        result = planner_node(state)
+
+        assert "plan" in result
+        plan = result["plan"]
+        assert plan.ticker == "NVDA"
+        assert plan.trade_type == "Day Trade"
+        assert len(plan.selected_subject_ids) >= 2
+        assert isinstance(plan.subject_focus, dict)
+        assert isinstance(plan.trade_context, str)
+        logger.info(
+            "Planner selected %d subjects: %s",
+            len(plan.selected_subject_ids),
+            plan.selected_subject_ids,
+        )
+        logger.info("Trade context: %s", plan.trade_context)
+
+    def test_planner_investment(self):
+        from agents.planner_node import planner_node
+
+        state = {
+            "ticker": "AAPL",
+            "trade_type": "Investment",
+            "conversation_context": "I want to understand AAPL's AI strategy and whether it justifies the premium valuation.",
+            "emitter": None,
+            "progress_fn": None,
+            "user_selected_subjects": None,
+            "spend_budget_usd": None,
+        }
+        result = planner_node(state)
+        plan = result["plan"]
+
+        assert len(plan.selected_subject_ids) >= 5  # Investment should get many subjects
+        # Focus hints ideally non-empty when user gave context, but model may fallback
+        non_empty_hints = [v for v in plan.subject_focus.values() if v]
+        if plan.planner_reasoning and "fallback" not in plan.planner_reasoning:
+            assert len(non_empty_hints) >= 1, "Planner should set focus hints based on user context"
+        else:
+            logger.warning("Planner used fallback — focus hints not tested")
+        logger.info("Plan: %s", json.dumps({
+            "subjects": plan.selected_subject_ids,
+            "focus": plan.subject_focus,
+            "context": plan.trade_context,
+        }, indent=2))
+
+
+# ---------------------------------------------------------------------------
+# Specialized Agent -- single subject, real LLM + tools
+# ---------------------------------------------------------------------------
+
+class TestSpecializedAgentLive:
+    """Test a single specialized agent with real tools and LLM."""
+
+    def test_valuation_aapl(self):
+        from agents.specialized_node import specialized_node
+        from research_plan import ResearchPlan
+
+        plan = ResearchPlan(
+            ticker="AAPL",
+            trade_type="Investment",
+            selected_subject_ids=["valuation"],
+            subject_focus={"valuation": "Focus on P/E relative to tech peers and DCF valuation"},
+            trade_context="Long-term investment analysis",
+            planner_reasoning="test",
+        )
+        state = {
+            "ticker": "AAPL",
+            "trade_type": "Investment",
+            "plan": plan,
+            "subject_id": "valuation",
+            "effective_max_turns": 6,
+            "effective_max_output_tokens": 4000,
+            "progress_fn": None,
+        }
+        result = specialized_node(state)
+
+        output = result["research_outputs"]["valuation"]
+        text = output["research_output"]
+
+        assert len(text) > 200, f"Output too short: {len(text)} chars"
+        assert "AAPL" in text.upper() or "apple" in text.lower(), "Should reference AAPL"
+
+        # Should contain actual numbers (our quality gate check)
+        import re
+        numbers = re.findall(r"\d+\.?\d*%?", text)
+        assert len(numbers) >= 3, f"Expected data points, found {len(numbers)}"
+
+        logger.info(
+            "Valuation output: %d chars, %d data points",
+            len(text), len(numbers),
+        )
+        # Print first 500 chars for manual inspection
+        logger.info("Preview: %s...", text[:500])
+
+
+# ---------------------------------------------------------------------------
+# Quality Gate -- verify with real-ish outputs
+# ---------------------------------------------------------------------------
+
+class TestQualityGateLive:
+    """Run quality gate on outputs that simulate real agent results."""
+
+    def test_gate_passes_real_style_output(self):
+        from research_graph import quality_gate_node
+
+        state = {
+            "ticker": "MSFT",
+            "emitter": None,
+            "research_outputs": {
+                "valuation": {
+                    "subject_id": "valuation",
+                    "subject_name": "Valuation Metrics",
+                    "research_output": (
+                        "## Valuation Analysis for MSFT\n\n"
+                        "Microsoft trades at a P/E of 34.2x, above the S&P 500 average of 21.5x. "
+                        "Forward P/E is 29.8x based on FY2027 EPS estimates of $15.42. "
+                        "Revenue grew 16.4% YoY to $65.6B in Q3 FY2026. "
+                        "Azure revenue grew 33% with 8 points from AI services. "
+                        "EV/EBITDA of 25.1x. Price-to-sales of 13.8x. "
+                        "Free cash flow of $22.1B representing a 33.7% FCF margin.\n\n"
+                        "**Key Takeaways**\n"
+                        "- P/E 34.2x vs sector 28.5x\n"
+                        "- Azure AI driving 8pp of cloud growth\n"
+                        "- FCF margin 33.7% on $65.6B revenue\n"
+                    ),
+                    "sources": [],
+                },
+                "growth_drivers": {
+                    "subject_id": "growth_drivers",
+                    "subject_name": "Growth Drivers",
+                    "research_output": (
+                        "## Growth Analysis for MSFT\n\n"
+                        "Microsoft's growth is driven by three pillars: Azure cloud (33% YoY), "
+                        "Microsoft 365 Copilot adoption (+18M paid seats), and gaming (Activision "
+                        "contributing $5.1B quarterly). Total revenue $65.6B, up 16.4%. "
+                        "Operating income grew 22% to $28.9B. AI revenue run rate exceeded $15B "
+                        "annualized. LinkedIn revenue grew 9% to $4.3B.\n\n"
+                        "**Key Takeaways**\n"
+                        "- Azure 33% growth with AI acceleration\n"
+                        "- Copilot: 18M paid seats\n"
+                        "- AI run rate: $15B+ annualized\n"
+                    ),
+                    "sources": [],
+                },
+            },
+        }
+        result = quality_gate_node(state)
+        assert result["failed_subjects"] == []
+        assert len(result["research_outputs"]) == 2
+        # Verify sources extracted from URLs (none in this case)
+        logger.info("Gate passed: %d subjects clean", len(result["research_outputs"]))
+
+
+# ---------------------------------------------------------------------------
+# Synthesis -- real LLM call with small input
+# ---------------------------------------------------------------------------
+
+class TestSynthesisLive:
+    """Test synthesis with real LLM on small input (2 subjects)."""
+
+    def test_synthesis_two_subjects(self):
+        from agents.synthesis_node import synthesis_node
+        from research_plan import ResearchPlan
+
+        plan = ResearchPlan(
+            ticker="MSFT",
+            trade_type="Investment",
+            selected_subject_ids=["valuation", "growth_drivers"],
+            subject_focus={
+                "valuation": "AI premium valuation",
+                "growth_drivers": "Azure and Copilot growth",
+            },
+            trade_context="User is evaluating MSFT as a long-term AI play.",
+            planner_reasoning="test",
+        )
+        state = {
+            "ticker": "MSFT",
+            "trade_type": "Investment",
+            "plan": plan,
+            "emitter": None,
+            "progress_fn": None,
+            "language": None,
+            "failed_subjects": [],
+            "research_outputs": {
+                "valuation": {
+                    "subject_name": "Valuation Metrics",
+                    "research_output": (
+                        "MSFT trades at P/E 34.2x vs sector 28.5x. Forward P/E 29.8x. "
+                        "Revenue $65.6B (+16.4% YoY). EV/EBITDA 25.1x. FCF $22.1B (33.7% margin). "
+                        "Price target consensus: $510 (14% upside from $448)."
+                    ),
+                    "focus_hint": "AI premium valuation",
+                    "sources": ["https://finance.yahoo.com/quote/MSFT"],
+                },
+                "growth_drivers": {
+                    "subject_name": "Growth Drivers",
+                    "research_output": (
+                        "Azure grew 33% with 8pp from AI. Copilot has 18M paid seats. "
+                        "AI revenue run rate $15B+ annualized. Gaming $5.1B/quarter (Activision). "
+                        "LinkedIn $4.3B (+9%). Operating income $28.9B (+22%)."
+                    ),
+                    "focus_hint": "Azure and Copilot growth",
+                    "sources": ["https://microsoft.com/investor"],
+                },
+            },
+        }
+        result = synthesis_node(state)
+
+        report = result["report_text"]
+        assert len(report) > 500, f"Report too short: {len(report)} chars"
+        assert "MSFT" in report or "Microsoft" in report
+        assert result.get("actual_input_tokens", 0) > 0
+        assert result.get("actual_output_tokens", 0) > 0
+
+        logger.info(
+            "Synthesis: %d chars, %d/%d tokens",
+            len(report),
+            result.get("actual_input_tokens", 0),
+            result.get("actual_output_tokens", 0),
+        )
+        # Check XML tags didn't leak into the output
+        assert "<instructions>" not in report
+        assert "<research_data>" not in report
+        logger.info("Report preview:\n%s", report[:1000])
+
+
+# ---------------------------------------------------------------------------
+# Tool Differentiation -- verify agents pick the right tools
+# ---------------------------------------------------------------------------
+
+class TestToolDifferentiationLive:
+    """Verify the updated tool descriptions lead to correct tool selection."""
+
+    def test_yfinance_tools_work(self):
+        """Smoke test that yfinance tools return real data."""
+        from langchain_tools import create_yfinance_tools
+
+        tools = create_yfinance_tools()
+        fundamentals = next(t for t in tools if t.name == "yfinance_fundamentals")
+        analyst = next(t for t in tools if t.name == "yfinance_analyst")
+
+        # Test fundamentals
+        result = json.loads(fundamentals.invoke({"symbol": "AAPL"}))
+        assert "error" not in result, f"Unexpected error: {result}"
+        assert "profile" in result
+        assert result["profile"]["symbol"] == "AAPL"
+
+        # Test analyst
+        result = json.loads(analyst.invoke({"symbol": "AAPL"}))
+        assert "error" not in result, f"Unexpected error: {result}"
+
+        logger.info("yfinance tools working correctly for AAPL")
+
+    def test_sec_edgar_tool_works(self):
+        """Smoke test SEC EDGAR tool."""
+        from langchain_tools import create_sec_edgar_tool
+
+        tool = create_sec_edgar_tool()
+        result = json.loads(tool.invoke({"symbol": "AAPL", "form_types": "10-K", "max_results": 2}))
+        assert isinstance(result, list)
+        assert len(result) > 0
+        assert "form_type" in result[0]
+        logger.info("SEC EDGAR returned %d filings for AAPL", len(result))
+
+
+# ---------------------------------------------------------------------------
+# Chat Agent -- verify logger.debug instead of print
+# ---------------------------------------------------------------------------
+
+class TestChatAgentLogging:
+    """Verify chat agent uses logger.debug, not print."""
+
+    def test_no_print_statements(self):
+        import inspect
+        from agents import chat_agent
+        source = inspect.getsource(chat_agent)
+        # Count print( calls -- should be 0
+        import re
+        prints = re.findall(r'^\s+print\(', source, re.MULTILINE)
+        assert len(prints) == 0, f"Found {len(prints)} print() calls in chat_agent.py"


### PR DESCRIPTION
Based on review against Anthropic reference books. Key changes:

- Differentiate nimble_web_search vs perplexity_research tool descriptions
- Add actionable error messages with suggestions to all tool error responses
- Delete stale prompt functions in research_prompt.py, fix src. import
- Add 10K char truncation to nimble_extract to prevent context overflow
- Replace print() with logger.debug() in chat_agent and research_graph
- Trim specialized agent prompt (~35 lines to ~20)
- Add 2 examples to planner prompt to reduce JSON parsing failures
- Add synthesis input budget (30K char cap with Key Takeaways preservation)
- Add quality gate heuristics (data point check, ticker reference check)
- Wrap synthesis prompt sections in XML tags for clearer structure
- Add 29 unit tests and 8 integration tests