### PR TITLE
fix: add MemorySaver checkpointer to research_graph (P0 #1)

### DIFF
--- a/src/research_graph.py
+++ b/src/research_graph.py
@@ -18,6 +18,7 @@ from typing import TypedDict, Dict, Any, Annotated, Optional, List
 
 from langgraph.graph import StateGraph, START, END
 from langgraph.types import Send
+from langgraph.checkpoint.memory import MemorySaver
 
 from agents.planner_node import planner_node
 from agents.specialized_node import specialized_node
@@ -315,7 +316,8 @@ _builder.add_conditional_edges(
 _builder.add_edge("synthesis_node", "storage_node")
 _builder.add_edge("storage_node", END)
 
-research_graph = _builder.compile()
+_checkpointer = MemorySaver()
+research_graph = _builder.compile(checkpointer=_checkpointer)
 
 
 def run_research(
@@ -370,7 +372,11 @@ def run_research(
         if username
         else f"{ticker.upper()} Research"
     )
-    invoke_config = {**(parent_config or {}), "run_name": run_name}
+    invoke_config = {
+        **(parent_config or {}),
+        "run_name": run_name,
+        "configurable": {"thread_id": str(uuid.uuid4())},
+    }
 
     result = research_graph.invoke(initial_state, config=invoke_config)
     return result


### PR DESCRIPTION
## What

Adds `MemorySaver` checkpointer to the LangGraph research pipeline — the last outstanding P0 fix from `docs/plans/2026-03-14-p0-fixes-plan.md`.

## Changes

- Import `MemorySaver` from `langgraph.checkpoint.memory`
- Compile `research_graph` with `checkpointer=MemorySaver()`
- Pass `configurable: {thread_id: uuid4()}` in `run_research()` invocation config (required by LangGraph when a checkpointer is present)

## Why

Without a checkpointer, interrupted research runs (e.g. on server restart or timeout) cannot be resumed. LangGraph also raises a `ValueError` if `thread_id` is missing when a checkpointer is attached.

## Notes

- `MemorySaver` is in-process only — state does not survive Flask restarts. Sufficient for P0; upgrade to `SqliteSaver` or `PostgresSaver` is a separate P1 task.
- P0 #2 (quality gate) and P0 #7 (truncation detection) were already implemented in the April 10 pipeline improvements commit.