### PR TITLE
fix: atomic alert trigger + deactivation

### DIFF
--- a/src/alerts/evaluation.py
+++ b/src/alerts/evaluation.py
@@ -126,11 +126,6 @@ def evaluate_alerts_for_symbols(db, symbols: Iterable[str]) -> int:
                 nid, alert["user_id"], alert["alert_id"], sym, body
             )
             _send_telegram_alert_if_connected(db, alert["user_id"], sym, body)
-            # One-shot: deactivate alert after successful trigger
-            try:
-                db.set_price_alert_active(alert["alert_id"], alert["user_id"], False)
-            except Exception:
-                logger.exception("failed to deactivate alert %s after trigger", alert.get("alert_id"))
             fired += 1
         except Exception:
             logger.exception(

--- a/src/database.py
+++ b/src/database.py
@@ -2164,7 +2164,7 @@ class DatabaseManager:
                 cur.execute(
                     """
                     UPDATE price_alerts
-                    SET last_triggered_at = NOW()
+                    SET last_triggered_at = NOW(), active = FALSE
                     WHERE alert_id = %s
                     """,
                     (alert_id,),

--- a/tests/test_alert_evaluation.py
+++ b/tests/test_alert_evaluation.py
@@ -48,6 +48,33 @@ def test_evaluate_fires_when_met(monkeypatch):
     assert call[1] == "u1"
     assert call[2] == "a1"
     assert "AAPL" in call[4] and "$" in call[4]
+    # set_price_alert_active should NOT be called -- deactivation is now
+    # handled atomically inside record_price_alert_trigger
+    db.set_price_alert_active.assert_not_called()
+
+
+def test_evaluate_no_partial_state_on_trigger_failure(monkeypatch):
+    """If record_price_alert_trigger raises, fired count stays 0."""
+    monkeypatch.setenv("STOCKPRO_ALERT_COOLDOWN_SEC", "0")
+    db = MagicMock()
+    db.list_active_alerts_for_symbols.return_value = [
+        {
+            "alert_id": "a1",
+            "user_id": "u1",
+            "symbol": "AAPL",
+            "asset_type": "stock",
+            "direction": "above",
+            "target_price": Decimal("100"),
+            "last_triggered_at": None,
+        }
+    ]
+    db.get_cached_prices.return_value = {
+        "AAPL": {"symbol": "AAPL", "asset_type": "stock", "price": Decimal("101")}
+    }
+    db.record_price_alert_trigger.side_effect = RuntimeError("DB error")
+    n = evaluate_alerts_for_symbols(db, ["AAPL"])
+    assert n == 0
+    db.set_price_alert_active.assert_not_called()
 
 
 def test_evaluate_respects_cooldown(monkeypatch):


### PR DESCRIPTION
## Summary
- Alerts no longer risk firing twice -- deactivation now happens in the same database operation as the notification
- Closes #27

## Test plan
- [x] `test_alert_evaluation.py` -- all 6 tests pass
- [x] Full test suite -- no regressions from this change

Generated with [Claude Code](https://claude.com/claude-code)