### PR TITLE
CLI: target live Railway backend by default

### DIFF
--- a/stockpro-cli/README.md
+++ b/stockpro-cli/README.md
@@ -1,0 +1,67 @@
+# StockPro CLI
+
+AI-powered stock research from your terminal. Talks to the StockPro backend over HTTPS.
+
+By default the CLI targets the live deployment at `https://stockpro-production-11c8.up.railway.app`.
+
+## Install
+
+From the repo root:
+
+```bash
+pip install -e stockpro-cli/
+```
+
+This registers the `stockpro` command.
+
+## First-time sign-in
+
+```bash
+stockpro auth login
+```
+
+Opens your browser to the StockPro Clerk sign-in page. After Google OAuth completes, the browser redirects to a short-lived local callback and the CLI stores your token at `~/.stockpro/config.json` (file mode `0600`).
+
+Confirm:
+
+```bash
+stockpro auth status
+```
+
+Sign out (clears the stored token):
+
+```bash
+stockpro auth logout
+```
+
+## Pointing at local Flask (dev)
+
+Precedence: `--api-url` flag > `STOCKPRO_API_URL` env var > `~/.stockpro/config.json` > default.
+
+Per invocation:
+
+```bash
+stockpro --api-url http://127.0.0.1:5000 auth status
+```
+
+Shell session:
+
+```bash
+export STOCKPRO_API_URL=http://127.0.0.1:5000
+stockpro auth status
+```
+
+Persist in the config file (only if you pass `--api-url` during `auth login`):
+
+```bash
+stockpro --api-url http://127.0.0.1:5000 auth login
+```
+
+## Commands
+
+Run `stockpro --help` for the full list. Common ones:
+
+- `stockpro auth login | logout | status`
+- `stockpro portfolio list`
+- `stockpro report list`
+- `stockpro watchlist list`

--- a/stockpro-cli/stockpro_cli/config.py
+++ b/stockpro-cli/stockpro_cli/config.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 CONFIG_DIR = Path.home() / ".stockpro"
 CONFIG_FILE = CONFIG_DIR / "config.json"
-DEFAULT_API_URL = "http://127.0.0.1:5000"
+DEFAULT_API_URL = "https://stockpro-production-11c8.up.railway.app"
 
 
 def _ensure_dir():


### PR DESCRIPTION
## Summary
- `DEFAULT_API_URL` in `stockpro-cli/stockpro_cli/config.py` is now the live Railway URL.
- Adds `stockpro-cli/README.md` with install, first-time sign-in, and dev override instructions.
- Existing override precedence (`--api-url` flag, `STOCKPRO_API_URL` env, persisted config) is unchanged, so local Flask dev still works via `STOCKPRO_API_URL=http://127.0.0.1:5000`.

## Test plan
- [x] `pip install -e stockpro-cli/` registers `stockpro` command
- [x] `stockpro auth login` opens browser to Railway Clerk page and stores token
- [x] `stockpro auth status` confirms authenticated against Railway
- [x] `STOCKPRO_API_URL=http://127.0.0.1:5000 stockpro auth status` still targets local Flask