### PR TITLE
feat: device-code auth for headless agents + CLI tokens UI

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -3715,9 +3715,10 @@ def device_authorize():
     from auth_tokens import create_device_code
 
     data = create_device_code()
-    data["verification_uri"] = (
-        request.host_url.rstrip("/") + "/app/device"
-    )
+    # Respect X-Forwarded-Proto so the printed URL uses https behind Railway's proxy.
+    scheme = request.headers.get("X-Forwarded-Proto", request.scheme)
+    host = request.headers.get("X-Forwarded-Host", request.host)
+    data["verification_uri"] = f"{scheme}://{host}/app/device"
     return jsonify(data)
 
 

--- a/src/app.py
+++ b/src/app.py
@@ -1165,9 +1165,144 @@ def api_health():
 @login_required
 def report_status(session_id: str):
     """Poll endpoint for background generation status."""
-    if session.get("session_id") != session_id:
+    user_id = session.get("user_id")
+    status = _generation_status.get(session_id)
+
+    # Web session ownership check (browser flow)
+    web_session_ok = session.get("session_id") == session_id
+    # API/CLI token ownership check (stateless generate endpoint)
+    api_owner_ok = status is not None and status.get("_owner_user_id") == user_id
+
+    if not web_session_ok and not api_owner_ok:
         return jsonify({"error": "forbidden"}), 403
-    return jsonify(_generation_status.get(session_id, {"status": "unknown"}))
+
+    if status is None:
+        return jsonify({"status": "unknown"})
+    return jsonify({k: v for k, v in status.items() if not k.startswith("_")})
+
+
+@app.route("/api/reports/generate", methods=["POST"])
+@csrf.exempt
+@login_required
+@limiter.limit(_report_gen_rate_limit, key_func=get_remote_address)
+def api_reports_generate():
+    """Stateless report generation endpoint for headless/CLI clients.
+
+    Accepts JSON body: {ticker, trade_type, context (optional)}
+    Returns: {success: true, session_id: "<uuid>"}
+    Poll GET /api/report_status/<session_id> until status == "ready" or "error".
+    """
+    data = request.get_json(force=True) or {}
+    ticker = (data.get("ticker") or "").strip().upper()
+    trade_type = (data.get("trade_type") or "").strip()
+    context_str = (data.get("context") or "").strip()
+
+    if not ticker or not trade_type:
+        return jsonify({"error": "ticker and trade_type are required"}), 400
+
+    if _session_hits_report_quota():
+        return _report_quota_json_error()
+
+    # Fresh session_id independent of any browser session
+    session_id = str(uuid.uuid4())
+    agent = initialize_session(session_id)
+    agent.reset_conversation()
+
+    user_id = session.get("user_id")
+    agent.user_id = user_id
+
+    # Username: prefer session (Clerk web flow), fall back to DB lookup (Bearer token)
+    agent.username = session.get("username")
+    if not agent.username and user_id:
+        try:
+            from database import get_database_manager as _get_db
+            _user_rec = _get_db().get_user_by_id(user_id)
+            if _user_rec:
+                agent.username = _user_rec.get("username", user_id)
+        except Exception:
+            agent.username = user_id
+
+    # Language preference from user profile
+    try:
+        from database import get_database_manager as _get_db2
+        _user_rec2 = _get_db2().get_user_by_id(user_id)
+        agent.language = (
+            (_user_rec2.get("preferences") or {}).get("language", "en") if _user_rec2 else "en"
+        )
+    except Exception:
+        agent.language = "en"
+
+    # Prime the orchestrator with ticker/trade_type (mirrors popup_start)
+    try:
+        agent.start_research(ticker, trade_type)
+    except Exception:
+        pass
+
+    from spend_budget import get_spend_budget_usd
+    spend_budget_usd = get_spend_budget_usd(agent.user_id)
+
+    _generation_status[session_id] = {
+        "status": "in_progress",
+        "report_id": None,
+        "progress": 5,
+        "step": "Starting...",
+        "_owner_user_id": user_id,
+    }
+
+    def run_generation():
+        import threading as _threading
+
+        subject_counter = {"done": 0, "total": 0}
+        counter_lock = _threading.Lock()
+
+        def progress_fn(progress, step):
+            status = _generation_status.get(session_id)
+            if status is None:
+                return
+            if progress is None:
+                with counter_lock:
+                    subject_counter["done"] += 1
+                    done = subject_counter["done"]
+                    total = subject_counter["total"] or 1
+                    pct = 20 + int((done / total) * 55)
+                    status["progress"] = min(pct, 75)
+                    status["step"] = f"Researching: {done}/{total} subjects done"
+            else:
+                status["progress"] = progress
+                status["step"] = step
+                if progress == 20 and "subjects" in step:
+                    try:
+                        subject_counter["total"] = int(step.split()[1])
+                    except (IndexError, ValueError):
+                        pass
+
+        emitter = create_emitter()
+        agent.set_emitter(emitter)
+        agent.set_progress_fn(progress_fn)
+        try:
+            agent.generate_report(
+                context=context_str,
+                spend_budget_usd=spend_budget_usd,
+            )
+            _generation_status[session_id] = {
+                "status": "ready",
+                "report_id": agent.current_report_id,
+                "progress": 100,
+                "step": "Report ready",
+                "_owner_user_id": user_id,
+            }
+        except Exception as e:
+            _generation_status[session_id] = {
+                "status": "error",
+                "message": str(e),
+                "_owner_user_id": user_id,
+            }
+        finally:
+            agent.set_emitter(None)
+            agent.set_progress_fn(None)
+
+    threading.Thread(target=run_generation, daemon=True).start()
+    return jsonify({"success": True, "session_id": session_id})
 
 
 @app.route("/api/position_check/<ticker>")

--- a/src/app.py
+++ b/src/app.py
@@ -215,6 +215,19 @@ def login_required(f):
     def decorated(*args, **kwargs):
         if "user_id" in session:
             return f(*args, **kwargs)
+
+        # Accept long-lived StockPro API tokens (CLI / headless agents).
+        auth_header = request.headers.get("Authorization", "")
+        if auth_header.startswith("Bearer sp_"):
+            from auth_tokens import verify_token
+
+            raw_token = auth_header.split(" ", 1)[1].strip()
+            user_id = verify_token(raw_token)
+            if user_id:
+                session["user_id"] = user_id
+                return f(*args, **kwargs)
+            return jsonify({"error": "Unauthorized"}), 401
+
         # Verify Clerk session token via authenticate_request
         request_state = clerk_client.authenticate_request(
             request, AuthenticateRequestOptions(jwt_key=CLERK_JWT_KEY)
@@ -3690,6 +3703,90 @@ try:
     register_ws_routes(app)
 except ImportError as e:
     app.logger.warning("WebSocket /ws/prices not registered: %s", e)
+
+
+# --- Device-code auth + CLI token management ---
+
+
+@app.route("/api/device/authorize", methods=["POST"])
+@limiter.limit("10/minute")
+def device_authorize():
+    """Start a device-code flow. No auth. Returns {device_code, user_code, expires_in, interval}."""
+    from auth_tokens import create_device_code
+
+    data = create_device_code()
+    data["verification_uri"] = (
+        request.host_url.rstrip("/") + "/app/device"
+    )
+    return jsonify(data)
+
+
+@app.route("/api/device/token", methods=["POST"])
+@limiter.limit("30/minute")
+def device_token():
+    """Agent polls here with its device_code. Returns status; includes access_token once approved."""
+    from auth_tokens import poll_device_code
+
+    body = request.get_json(silent=True) or {}
+    device_code = (body.get("device_code") or "").strip()
+    if not device_code:
+        return jsonify({"error": "device_code required"}), 400
+    result = poll_device_code(device_code)
+    if result.get("status") == "unknown":
+        return jsonify({"status": "pending"}), 200  # don't leak existence
+    return jsonify(result)
+
+
+@app.route("/api/device/approve", methods=["POST"])
+@login_required
+def device_approve():
+    """Master approves a user_code for their account. Called from /app/device."""
+    from auth_tokens import approve_device_code
+
+    body = request.get_json(silent=True) or {}
+    user_code = body.get("user_code") or ""
+    result = approve_device_code(session["user_id"], user_code)
+    if "error" in result:
+        code = 404 if result["error"] in ("unknown_code", "invalid_code") else 410
+        return jsonify(result), code
+    return jsonify(result)
+
+
+@app.route("/api/tokens", methods=["GET"])
+@login_required
+def tokens_list():
+    from auth_tokens import list_api_keys
+
+    return jsonify({"tokens": list_api_keys(session["user_id"])})
+
+
+@app.route("/api/tokens", methods=["POST"])
+@login_required
+def tokens_create():
+    """Create a token. Returns raw token ONCE."""
+    from auth_tokens import create_api_key
+
+    body = request.get_json(silent=True) or {}
+    name = (body.get("name") or "CLI token").strip()[:100] or "CLI token"
+    key_id, raw_token = create_api_key(session["user_id"], name)
+    return jsonify(
+        {
+            "id": key_id,
+            "name": name,
+            "access_token": raw_token,
+        }
+    )
+
+
+@app.route("/api/tokens/<key_id>", methods=["DELETE"])
+@login_required
+def tokens_revoke(key_id):
+    from auth_tokens import revoke_api_key
+
+    ok = revoke_api_key(session["user_id"], key_id)
+    if not ok:
+        return jsonify({"error": "not_found"}), 404
+    return jsonify({"status": "revoked"})
 
 
 # --- SPA serving (production) ---

--- a/src/auth_tokens.py
+++ b/src/auth_tokens.py
@@ -256,6 +256,9 @@ def poll_device_code(device_code: str) -> dict:
 def approve_device_code(user_id: str, user_code: str) -> dict:
     """Approve a user_code for a user. Issues an api_key and stashes the raw token on the device_codes row
     so the next poll can hand it back. Returns {status, token_name} or {error}.
+
+    Uses a single connection for the whole flow -- avoids nesting pool.getconn() calls
+    which was contributing to pool exhaustion under load.
     """
     code = normalize_user_code(user_code)
     if len(code) != _USER_CODE_LEN:
@@ -279,9 +282,21 @@ def approve_device_code(user_id: str, user_code: str) -> dict:
             if row["approved_at"] is not None:
                 return {"error": "already_approved"}
 
-            # Issue a token
+            # Issue token on THIS connection (don't nest get_connection).
+            raw_bytes = secrets.token_urlsafe(32)
+            raw_token = f"{TOKEN_PREFIX}{raw_bytes}"
+            prefix = raw_token[: len(TOKEN_PREFIX) + 4]
+            token_hash = _hash_token(raw_token)
+            api_key_id = str(uuid.uuid4())
             name = f"CLI device ({code[:4]})"
-            api_key_id, raw_token = create_api_key(user_id, name)
+
+            cur.execute(
+                """
+                INSERT INTO api_keys (id, user_id, name, token_hash, prefix)
+                VALUES (%s, %s, %s, %s, %s)
+                """,
+                (api_key_id, user_id, name[:100], token_hash, prefix),
+            )
 
             cur.execute(
                 """

--- a/src/auth_tokens.py
+++ b/src/auth_tokens.py
@@ -1,0 +1,297 @@
+"""
+Long-lived API tokens for CLI / headless agents.
+
+Tokens are issued either via the device-code flow (agent prints a user code,
+master approves in browser) or directly from the Settings UI. Tokens are
+stored as SHA-256 hashes; the raw token is only returned once on creation.
+"""
+
+import hashlib
+import logging
+import secrets
+import uuid
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+
+import psycopg2.extras
+
+from database import get_database_manager
+
+logger = logging.getLogger(__name__)
+
+TOKEN_PREFIX = "sp_"
+# Crockford-ish alphabet: no 0, O, 1, I, L.
+_USER_CODE_ALPHABET = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789"
+_USER_CODE_LEN = 8
+_DEVICE_CODE_TTL = timedelta(minutes=10)
+_LAST_USED_THROTTLE = timedelta(minutes=1)
+
+
+def _hash_token(raw: str) -> str:
+    return hashlib.sha256(raw.encode("utf-8")).hexdigest()
+
+
+def _generate_user_code() -> str:
+    return "".join(secrets.choice(_USER_CODE_ALPHABET) for _ in range(_USER_CODE_LEN))
+
+
+def format_user_code(code: str) -> str:
+    """Insert a hyphen for display: ABCD1234 -> ABCD-1234."""
+    if len(code) == 8:
+        return f"{code[:4]}-{code[4:]}"
+    return code
+
+
+def normalize_user_code(raw: str) -> str:
+    """Strip whitespace/hyphens, uppercase. Users may paste 'abcd-1234' or ' AbCd1234 '."""
+    return "".join(ch for ch in raw.upper() if ch in _USER_CODE_ALPHABET)
+
+
+# ----- API key CRUD -----
+
+
+def create_api_key(user_id: str, name: str) -> tuple[str, str]:
+    """Issue a new token. Returns (api_key_id, raw_token). Raw token is shown once."""
+    raw_bytes = secrets.token_urlsafe(32)
+    raw_token = f"{TOKEN_PREFIX}{raw_bytes}"
+    prefix = raw_token[: len(TOKEN_PREFIX) + 4]
+    token_hash = _hash_token(raw_token)
+    api_key_id = str(uuid.uuid4())
+
+    db = get_database_manager()
+    conn = db.get_connection()
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                INSERT INTO api_keys (id, user_id, name, token_hash, prefix)
+                VALUES (%s, %s, %s, %s, %s)
+                """,
+                (api_key_id, user_id, name[:100], token_hash, prefix),
+            )
+        conn.commit()
+    finally:
+        db._release(conn)
+    return api_key_id, raw_token
+
+
+def verify_token(raw_token: str) -> Optional[str]:
+    """Look up a token; return user_id if valid (not revoked), else None.
+
+    Also refreshes last_used_at at most once per minute to avoid a DB write per call.
+    """
+    if not raw_token or not raw_token.startswith(TOKEN_PREFIX):
+        return None
+    token_hash = _hash_token(raw_token)
+
+    db = get_database_manager()
+    conn = db.get_connection()
+    try:
+        with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+            cur.execute(
+                """
+                SELECT id, user_id, last_used_at, revoked_at
+                FROM api_keys WHERE token_hash = %s
+                """,
+                (token_hash,),
+            )
+            row = cur.fetchone()
+            if not row or row["revoked_at"] is not None:
+                return None
+            now = datetime.now(timezone.utc)
+            last_used = row["last_used_at"]
+            if last_used is None or (now - last_used) > _LAST_USED_THROTTLE:
+                cur.execute(
+                    "UPDATE api_keys SET last_used_at = %s WHERE id = %s",
+                    (now, row["id"]),
+                )
+                conn.commit()
+            return row["user_id"]
+    finally:
+        db._release(conn)
+
+
+def list_api_keys(user_id: str) -> list[dict]:
+    """Return non-revoked keys for this user. Never includes hash/raw token."""
+    db = get_database_manager()
+    conn = db.get_connection()
+    try:
+        with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+            cur.execute(
+                """
+                SELECT id, name, prefix, created_at, last_used_at
+                FROM api_keys
+                WHERE user_id = %s AND revoked_at IS NULL
+                ORDER BY created_at DESC
+                """,
+                (user_id,),
+            )
+            rows = cur.fetchall()
+    finally:
+        db._release(conn)
+    # Convert timestamps to ISO strings for JSON
+    out = []
+    for r in rows:
+        out.append(
+            {
+                "id": r["id"],
+                "name": r["name"],
+                "prefix": r["prefix"],
+                "created_at": r["created_at"].isoformat() if r["created_at"] else None,
+                "last_used_at": r["last_used_at"].isoformat() if r["last_used_at"] else None,
+            }
+        )
+    return out
+
+
+def revoke_api_key(user_id: str, key_id: str) -> bool:
+    """Mark a key revoked. Returns True if something was revoked."""
+    db = get_database_manager()
+    conn = db.get_connection()
+    try:
+        with conn.cursor() as cur:
+            cur.execute(
+                """
+                UPDATE api_keys SET revoked_at = NOW()
+                WHERE id = %s AND user_id = %s AND revoked_at IS NULL
+                """,
+                (key_id, user_id),
+            )
+            changed = cur.rowcount
+        conn.commit()
+    finally:
+        db._release(conn)
+    return changed > 0
+
+
+# ----- Device-code flow -----
+
+
+def create_device_code() -> dict:
+    """Register a pending device authorization. Returns flow parameters (no secrets for other users)."""
+    device_code = secrets.token_urlsafe(48)
+    # Retry to avoid collisions on the short user_code
+    for _ in range(5):
+        user_code = _generate_user_code()
+        try:
+            db = get_database_manager()
+            conn = db.get_connection()
+            try:
+                with conn.cursor() as cur:
+                    cur.execute(
+                        """
+                        INSERT INTO device_codes (device_code, user_code, expires_at)
+                        VALUES (%s, %s, NOW() + INTERVAL '10 minutes')
+                        """,
+                        (device_code, user_code),
+                    )
+                conn.commit()
+                break
+            finally:
+                db._release(conn)
+        except psycopg2.IntegrityError:
+            # user_code collision, try another
+            continue
+    else:
+        raise RuntimeError("Could not generate a unique user code")
+
+    return {
+        "device_code": device_code,
+        "user_code": format_user_code(user_code),
+        "expires_in": int(_DEVICE_CODE_TTL.total_seconds()),
+        "interval": 5,
+    }
+
+
+def poll_device_code(device_code: str) -> dict:
+    """Return one of:
+      {"status": "pending"}
+      {"status": "expired"}
+      {"status": "approved", "access_token": "sp_..."}  <-- only once, row is deleted after
+      {"status": "unknown"}  <-- device_code not found
+    """
+    db = get_database_manager()
+    conn = db.get_connection()
+    try:
+        with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+            cur.execute(
+                "SELECT user_id, api_key_id, expires_at, approved_at FROM device_codes WHERE device_code = %s",
+                (device_code,),
+            )
+            row = cur.fetchone()
+            if not row:
+                return {"status": "unknown"}
+
+            now = datetime.now(timezone.utc)
+            expires_at = row["expires_at"]
+            if expires_at and expires_at < now:
+                cur.execute("DELETE FROM device_codes WHERE device_code = %s", (device_code,))
+                conn.commit()
+                return {"status": "expired"}
+
+            if row["approved_at"] is None:
+                return {"status": "pending"}
+
+            # Approved: issue the raw token once and delete the row.
+            # The raw token was never stored — we need to regenerate via a fresh api_key.
+            # To avoid this, the approve step stores the raw token transiently on the device_codes row.
+            # Simplest implementation: keep a plaintext column for 10 minutes max.
+            # We'll add a small column `access_token` below in approve flow.
+            # (See approve_device_code — it stashes the raw token on the row.)
+            cur.execute(
+                "SELECT access_token FROM device_codes WHERE device_code = %s",
+                (device_code,),
+            )
+            token_row = cur.fetchone()
+            cur.execute("DELETE FROM device_codes WHERE device_code = %s", (device_code,))
+            conn.commit()
+            return {
+                "status": "approved",
+                "access_token": token_row["access_token"] if token_row else None,
+            }
+    finally:
+        db._release(conn)
+
+
+def approve_device_code(user_id: str, user_code: str) -> dict:
+    """Approve a user_code for a user. Issues an api_key and stashes the raw token on the device_codes row
+    so the next poll can hand it back. Returns {status, token_name} or {error}.
+    """
+    code = normalize_user_code(user_code)
+    if len(code) != _USER_CODE_LEN:
+        return {"error": "invalid_code"}
+
+    db = get_database_manager()
+    conn = db.get_connection()
+    try:
+        with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+            cur.execute(
+                "SELECT device_code, expires_at, approved_at FROM device_codes WHERE user_code = %s",
+                (code,),
+            )
+            row = cur.fetchone()
+            if not row:
+                return {"error": "unknown_code"}
+
+            now = datetime.now(timezone.utc)
+            if row["expires_at"] and row["expires_at"] < now:
+                return {"error": "expired"}
+            if row["approved_at"] is not None:
+                return {"error": "already_approved"}
+
+            # Issue a token
+            name = f"CLI device ({code[:4]})"
+            api_key_id, raw_token = create_api_key(user_id, name)
+
+            cur.execute(
+                """
+                UPDATE device_codes
+                SET user_id = %s, api_key_id = %s, approved_at = NOW(), access_token = %s
+                WHERE device_code = %s
+                """,
+                (user_id, api_key_id, raw_token, row["device_code"]),
+            )
+        conn.commit()
+        return {"status": "approved", "token_name": name}
+    finally:
+        db._release(conn)

--- a/src/database.py
+++ b/src/database.py
@@ -73,16 +73,28 @@ class DatabaseManager:
             conn = self.get_connection()
             with conn.cursor() as cur:
 
-                # Trigger function for updated_at auto-update
-                cur.execute("""
-                    CREATE OR REPLACE FUNCTION update_updated_at()
-                    RETURNS TRIGGER AS $$
-                    BEGIN
-                      NEW.updated_at = NOW();
-                      RETURN NEW;
-                    END;
-                    $$ LANGUAGE plpgsql
-                """)
+                # Give this session extra headroom for lock waits during rolling deploys
+                # (old container may still hold pg_proc share locks via active triggers).
+                cur.execute("SET LOCAL statement_timeout = '60s'")
+                cur.execute("SET LOCAL lock_timeout = '30s'")
+
+                # Trigger function for updated_at auto-update.
+                # Skip CREATE OR REPLACE if the function already exists -- that path
+                # takes an exclusive lock on pg_proc and will time out during a
+                # rolling deploy while the old container is still running triggers.
+                cur.execute(
+                    "SELECT 1 FROM pg_proc WHERE proname = 'update_updated_at' LIMIT 1"
+                )
+                if cur.fetchone() is None:
+                    cur.execute("""
+                        CREATE OR REPLACE FUNCTION update_updated_at()
+                        RETURNS TRIGGER AS $$
+                        BEGIN
+                          NEW.updated_at = NOW();
+                          RETURN NEW;
+                        END;
+                        $$ LANGUAGE plpgsql
+                    """)
 
                 # Users
                 cur.execute("""

--- a/src/database.py
+++ b/src/database.py
@@ -490,6 +490,68 @@ class DatabaseManager:
                     "CREATE INDEX IF NOT EXISTS idx_report_usage_period ON report_usage (period)"
                 )
 
+                # Long-lived API tokens for CLI / headless agents
+                cur.execute("""
+                    CREATE TABLE IF NOT EXISTS api_keys (
+                        id           VARCHAR(36) PRIMARY KEY,
+                        user_id      VARCHAR(36) NOT NULL REFERENCES users(user_id) ON DELETE CASCADE,
+                        name         VARCHAR(100) NOT NULL,
+                        token_hash   VARCHAR(64)  NOT NULL UNIQUE,
+                        prefix       VARCHAR(16)  NOT NULL,
+                        created_at   TIMESTAMPTZ DEFAULT NOW(),
+                        last_used_at TIMESTAMPTZ,
+                        revoked_at   TIMESTAMPTZ
+                    )
+                """)
+                cur.execute(
+                    "CREATE INDEX IF NOT EXISTS idx_api_keys_user_id ON api_keys (user_id)"
+                )
+                cur.execute(
+                    "CREATE INDEX IF NOT EXISTS idx_api_keys_token_hash ON api_keys (token_hash)"
+                )
+
+                # Device-code flow: pending agent authorizations awaiting user approval.
+                # access_token holds the raw token between approval and the next agent poll
+                # (max 10 min, deleted on first successful poll).
+                cur.execute("""
+                    CREATE TABLE IF NOT EXISTS device_codes (
+                        device_code  VARCHAR(128) PRIMARY KEY,
+                        user_code    VARCHAR(16)  NOT NULL UNIQUE,
+                        user_id      VARCHAR(36)  REFERENCES users(user_id) ON DELETE CASCADE,
+                        api_key_id   VARCHAR(36)  REFERENCES api_keys(id) ON DELETE SET NULL,
+                        expires_at   TIMESTAMPTZ  NOT NULL,
+                        approved_at  TIMESTAMPTZ,
+                        access_token TEXT,
+                        created_at   TIMESTAMPTZ  DEFAULT NOW()
+                    )
+                """)
+                cur.execute(
+                    "CREATE INDEX IF NOT EXISTS idx_device_codes_user_code ON device_codes (user_code)"
+                )
+                cur.execute(
+                    "CREATE INDEX IF NOT EXISTS idx_device_codes_expires_at ON device_codes (expires_at)"
+                )
+
+                # RLS: backend uses the postgres role (bypasses RLS); these policies
+                # only matter for any client that ever connects as `authenticated` or `anon`.
+                cur.execute("ALTER TABLE api_keys ENABLE ROW LEVEL SECURITY")
+                cur.execute("DROP POLICY IF EXISTS api_keys_owner ON api_keys")
+                cur.execute(
+                    "CREATE POLICY api_keys_owner ON api_keys "
+                    "FOR ALL USING (user_id = auth.jwt()->>'sub') "
+                    "WITH CHECK (user_id = auth.jwt()->>'sub')"
+                )
+
+                cur.execute("ALTER TABLE device_codes ENABLE ROW LEVEL SECURITY")
+                cur.execute("DROP POLICY IF EXISTS device_codes_owner ON device_codes")
+                # Once approved, the owner can read their pending/approved rows.
+                # Pre-approval rows have user_id=NULL and are only accessible by service_role.
+                cur.execute(
+                    "CREATE POLICY device_codes_owner ON device_codes "
+                    "FOR ALL USING (user_id = auth.jwt()->>'sub') "
+                    "WITH CHECK (user_id = auth.jwt()->>'sub')"
+                )
+
             conn.commit()
             logger.info("Database schema initialized")
 

--- a/stockpro-cli/README.md
+++ b/stockpro-cli/README.md
@@ -34,6 +34,35 @@ Sign out (clears the stored token):
 stockpro auth logout
 ```
 
+## Headless / serverless (no browser)
+
+For agents running in a serverless environment (no browser to open), use the device-code flow. The agent prints a code; the user opens the URL on any device, signs in, and approves.
+
+```bash
+stockpro auth device-login
+```
+
+Output:
+
+```
+Open https://stockpro-production-11c8.up.railway.app/app/device?user_code=ABCD1234 on any browser,
+sign in, and confirm code: ABCD1234
+(expires in 10 min). Waiting...
+```
+
+Once approved, the token is saved to `~/.stockpro/config.json` just like `auth login`.
+
+### Token injection via env var
+
+If the agent already has a token (e.g. generated from the Settings -> CLI tokens page on the web app), skip the device flow entirely:
+
+```bash
+export STOCKPRO_TOKEN=sp_xxxxxxxxxxxxxxxx
+stockpro portfolio list
+```
+
+`STOCKPRO_TOKEN` takes precedence over `~/.stockpro/config.json`. Perfect for injecting into serverless runtimes as a secret.
+
 ## Pointing at local Flask (dev)
 
 Precedence: `--api-url` flag > `STOCKPRO_API_URL` env var > `~/.stockpro/config.json` > default.

--- a/stockpro-cli/stockpro_cli/auth.py
+++ b/stockpro-cli/stockpro_cli/auth.py
@@ -1,8 +1,10 @@
 """Login/logout/status via browser OAuth + localhost callback."""
 
 import click
+import httpx
 import json
 import sys
+import time
 import webbrowser
 from http.server import HTTPServer, BaseHTTPRequestHandler
 from urllib.parse import urlparse, parse_qs
@@ -69,6 +71,79 @@ def login(ctx):
         json.dump({"error": "Authentication failed -- no token received"}, sys.stderr)
         sys.stderr.write("\n")
         sys.exit(1)
+
+
+@auth.command("device-login")
+@click.pass_context
+def device_login(ctx):
+    """Authenticate headlessly via device code (no browser on this machine)."""
+    api_url = (ctx.obj.get("api_url") or get_api_url()).rstrip("/")
+
+    try:
+        resp = httpx.post(f"{api_url}/api/device/authorize", timeout=30.0)
+    except httpx.HTTPError as exc:
+        json.dump({"error": f"Failed to reach {api_url}: {exc}"}, sys.stderr)
+        sys.stderr.write("\n")
+        sys.exit(1)
+
+    if resp.status_code != 200:
+        json.dump({"error": f"authorize failed ({resp.status_code}): {resp.text[:200]}"}, sys.stderr)
+        sys.stderr.write("\n")
+        sys.exit(1)
+
+    data = resp.json()
+    device_code = data["device_code"]
+    user_code = data["user_code"]
+    verification_uri = data["verification_uri"]
+    expires_in = int(data.get("expires_in", 600))
+    interval = max(1, int(data.get("interval", 5)))
+
+    click.echo(
+        f"Open {verification_uri}?user_code={user_code} on any browser,\n"
+        f"sign in, and confirm code: {user_code}\n"
+        f"(expires in {expires_in // 60} min). Waiting...",
+        err=True,
+    )
+
+    deadline = time.time() + expires_in
+    while time.time() < deadline:
+        time.sleep(interval)
+        try:
+            poll = httpx.post(
+                f"{api_url}/api/device/token",
+                json={"device_code": device_code},
+                timeout=30.0,
+            )
+        except httpx.HTTPError as exc:
+            json.dump({"error": f"poll failed: {exc}"}, sys.stderr)
+            sys.stderr.write("\n")
+            sys.exit(1)
+
+        if poll.status_code == 429:
+            interval = min(interval * 2, 30)
+            continue
+
+        body = poll.json() if poll.content else {}
+        status_value = body.get("status")
+
+        if status_value == "pending":
+            continue
+        if status_value == "expired":
+            json.dump({"error": "Device code expired. Run again."}, sys.stderr)
+            sys.stderr.write("\n")
+            sys.exit(1)
+        if status_value == "approved" and body.get("access_token"):
+            cfg = load_config()
+            cfg["access_token"] = body["access_token"]
+            if ctx.obj.get("api_url"):
+                cfg["api_url"] = ctx.obj["api_url"]
+            save_config(cfg)
+            output({"status": "authenticated"}, ctx.obj.get("pretty", False))
+            return
+
+    json.dump({"error": "Device code expired before approval."}, sys.stderr)
+    sys.stderr.write("\n")
+    sys.exit(1)
 
 
 @auth.command()

--- a/stockpro-cli/stockpro_cli/commands/reports.py
+++ b/stockpro-cli/stockpro_cli/commands/reports.py
@@ -1,5 +1,6 @@
 """Research report commands."""
 
+import time
 import click
 from stockpro_cli.client import get_client
 from stockpro_cli.output import output
@@ -9,6 +10,76 @@ from stockpro_cli.output import output
 def reports():
     """Manage research reports."""
     pass
+
+
+@reports.command("generate")
+@click.option("--ticker", required=True, help="Stock ticker symbol (e.g. AAPL)")
+@click.option(
+    "--trade-type",
+    required=True,
+    type=click.Choice(["Investment", "Swing Trade", "Day Trade"], case_sensitive=False),
+    help="Type of trade to research",
+)
+@click.option("--context", default="", help="Optional research context or notes")
+@click.option(
+    "--poll-interval",
+    default=5,
+    show_default=True,
+    type=int,
+    help="Seconds between status polls",
+)
+@click.pass_context
+def generate(ctx, ticker, trade_type, context, poll_interval):
+    """Generate a new research report. Polls until complete."""
+    client = get_client(ctx.obj.get("api_url"))
+    pretty = ctx.obj.get("pretty", False)
+
+    # Kick off generation
+    resp = client.post(
+        "/api/reports/generate",
+        data={"ticker": ticker, "trade_type": trade_type, "context": context},
+    )
+    if not resp.get("success"):
+        output(resp, pretty)
+        return
+
+    session_id = resp.get("session_id")
+    if not session_id:
+        output({"error": "No session_id returned from server"}, pretty)
+        return
+
+    if pretty:
+        click.echo(f"Generating report for {ticker} ({trade_type})...")
+
+    # Poll until ready or error
+    last_step = ""
+    while True:
+        status = client.get(f"/api/report_status/{session_id}")
+        state = status.get("status", "unknown")
+        step = status.get("step", "")
+        progress = status.get("progress", 0)
+
+        if pretty and step and step != last_step:
+            click.echo(f"  [{progress:>3}%] {step}")
+            last_step = step
+
+        if state == "ready":
+            report_id = status.get("report_id")
+            if pretty:
+                click.echo(f"\nDone! Report ID: {report_id}")
+            else:
+                output({"status": "ready", "report_id": report_id}, pretty)
+            return
+
+        if state == "error":
+            msg = status.get("message", "Unknown error")
+            if pretty:
+                click.echo(f"\nError: {msg}", err=True)
+            else:
+                output({"status": "error", "message": msg}, pretty)
+            raise SystemExit(1)
+
+        time.sleep(poll_interval)
 
 
 @reports.command("list")

--- a/stockpro-cli/stockpro_cli/config.py
+++ b/stockpro-cli/stockpro_cli/config.py
@@ -34,7 +34,7 @@ def get_api_url() -> str:
 
 
 def get_token() -> str | None:
-    return load_config().get("access_token")
+    return os.environ.get("STOCKPRO_TOKEN") or load_config().get("access_token")
 
 
 def clear_auth():

--- a/stockpro-web/src/App.tsx
+++ b/stockpro-web/src/App.tsx
@@ -304,9 +304,19 @@ export default function App() {
       <Route
         path="/device"
         element={
-          <SignedIn>
-            <DevicePage />
-          </SignedIn>
+          <>
+            <SignedIn>
+              <DevicePage />
+            </SignedIn>
+            <SignedOut>
+              <Navigate
+                to={`/sign-in?redirect_url=${encodeURIComponent(
+                  typeof window !== 'undefined' ? window.location.pathname + window.location.search : '/device'
+                )}`}
+                replace
+              />
+            </SignedOut>
+          </>
         }
       />
 

--- a/stockpro-web/src/App.tsx
+++ b/stockpro-web/src/App.tsx
@@ -26,6 +26,7 @@ const Watchlist = lazy(() => import('./pages/Watchlist'))
 const Alerts = lazy(() => import('./pages/Alerts'))
 const TickerPage = lazy(() => import('./pages/TickerPage'))
 const Settings = lazy(() => import('./pages/Settings'))
+const DevicePage = lazy(() => import('./pages/DevicePage'))
 
 /**
  * Runs at app level (never unmounts on navigation) so toast dedup works.
@@ -296,6 +297,15 @@ export default function App() {
         element={
           <SignedIn>
             <Settings />
+          </SignedIn>
+        }
+      />
+
+      <Route
+        path="/device"
+        element={
+          <SignedIn>
+            <DevicePage />
           </SignedIn>
         }
       />

--- a/stockpro-web/src/locales/en.json
+++ b/stockpro-web/src/locales/en.json
@@ -223,6 +223,7 @@
   "settings.notifications": "Notifications",
   "settings.researchDefaults": "Research defaults",
   "settings.telegram": "Telegram",
+  "settings.cli": "CLI tokens",
   "settings.plan": "Plan",
   "settings.dangerZone": "Danger zone",
   "settings.editProfile": "Edit profile",

--- a/stockpro-web/src/locales/he.json
+++ b/stockpro-web/src/locales/he.json
@@ -223,6 +223,7 @@
   "settings.notifications": "\u05d4\u05ea\u05e8\u05d0\u05d5\u05ea",
   "settings.researchDefaults": "\u05d1\u05e8\u05d9\u05e8\u05d5\u05ea \u05de\u05d7\u05d3\u05dc \u05de\u05d7\u05e7\u05e8",
   "settings.telegram": "Telegram",
+  "settings.cli": "\u05d0\u05e1\u05d9\u05de\u05d5\u05e0\u05d9 CLI",
   "settings.plan": "\u05de\u05e0\u05d5\u05d9",
   "settings.dangerZone": "\u05d0\u05d6\u05d5\u05e8 \u05de\u05e1\u05d5\u05db\u05df",
   "settings.editProfile": "\u05e2\u05e8\u05d5\u05da \u05e4\u05e8\u05d5\u05e4\u05d9\u05dc",

--- a/stockpro-web/src/pages/DevicePage.tsx
+++ b/stockpro-web/src/pages/DevicePage.tsx
@@ -1,0 +1,142 @@
+import { useEffect, useState } from 'react'
+import { useSearchParams } from 'react-router'
+import AppNav from '../components/AppNav'
+import { useApiClient } from '../api/client'
+
+type Status = 'idle' | 'submitting' | 'approved' | 'error'
+
+export default function DevicePage() {
+  const api = useApiClient()
+  const [params] = useSearchParams()
+  const [code, setCode] = useState(() => (params.get('user_code') || '').toUpperCase())
+  const [status, setStatus] = useState<Status>('idle')
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    const fromUrl = params.get('user_code')
+    if (fromUrl) setCode(fromUrl.toUpperCase())
+  }, [params])
+
+  async function approve() {
+    setStatus('submitting')
+    setError(null)
+    const res = await api.post('/api/device/approve', { user_code: code })
+    if (res.ok) {
+      setStatus('approved')
+      return
+    }
+    const body = await res.json().catch(() => ({}))
+    const reason = body.error || 'unknown_error'
+    setError(
+      reason === 'unknown_code'
+        ? 'That code is not valid. Check the code printed in your terminal.'
+        : reason === 'expired'
+          ? 'That code has expired. Start a new login from your agent.'
+          : reason === 'already_approved'
+            ? 'That code was already approved.'
+            : 'Something went wrong. Try again.'
+    )
+    setStatus('error')
+  }
+
+  return (
+    <div style={{ background: '#0c0a09', minHeight: '100vh', color: '#d6d3d1', fontFamily: 'Inter, sans-serif' }}>
+      <AppNav />
+      <div
+        style={{
+          maxWidth: 480,
+          margin: '0 auto',
+          padding: '64px 24px',
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 24,
+        }}
+      >
+        <div>
+          <h1 style={{ fontFamily: 'Nunito, sans-serif', fontSize: 28, fontWeight: 700, margin: 0 }}>
+            Authorize device
+          </h1>
+          <p style={{ color: '#a8a29e', marginTop: 8, fontSize: 14, lineHeight: 1.5 }}>
+            Enter the code shown in your terminal to let that device act on your behalf. Approving
+            issues a long-lived CLI token you can revoke later in Settings.
+          </p>
+        </div>
+
+        {status === 'approved' ? (
+          <div
+            style={{
+              background: '#1c1917',
+              border: '1px solid #22c55e',
+              borderRadius: 16,
+              padding: 24,
+              display: 'flex',
+              flexDirection: 'column',
+              gap: 8,
+            }}
+          >
+            <div style={{ fontSize: 16, fontWeight: 600, color: '#22c55e' }}>Device authorized</div>
+            <div style={{ color: '#a8a29e', fontSize: 14 }}>
+              You can close this window. The agent terminal should now show "authenticated".
+            </div>
+          </div>
+        ) : (
+          <div
+            style={{
+              background: '#1c1917',
+              border: '1px solid #292524',
+              borderRadius: 16,
+              padding: 24,
+              display: 'flex',
+              flexDirection: 'column',
+              gap: 16,
+            }}
+          >
+            <label htmlFor="code" style={{ fontSize: 13, color: '#a8a29e' }}>
+              Code from your agent
+            </label>
+            <input
+              id="code"
+              value={code}
+              onChange={e => setCode(e.target.value.toUpperCase())}
+              placeholder="ABCD-1234"
+              autoFocus
+              autoComplete="off"
+              spellCheck={false}
+              style={{
+                background: '#0c0a09',
+                border: '1px solid #292524',
+                borderRadius: 10,
+                padding: '14px 16px',
+                color: '#fafaf9',
+                fontFamily: 'ui-monospace, monospace',
+                fontSize: 20,
+                letterSpacing: 2,
+                textAlign: 'center',
+              }}
+            />
+            {error && (
+              <div style={{ color: '#ef4444', fontSize: 13 }}>{error}</div>
+            )}
+            <button
+              onClick={approve}
+              disabled={status === 'submitting' || code.replace(/[-\s]/g, '').length < 8}
+              style={{
+                background: '#d6d3d1',
+                color: '#0c0a09',
+                padding: '12px 16px',
+                borderRadius: 999,
+                border: 0,
+                fontWeight: 600,
+                fontSize: 14,
+                cursor: status === 'submitting' ? 'progress' : 'pointer',
+                opacity: code.replace(/[-\s]/g, '').length < 8 ? 0.5 : 1,
+              }}
+            >
+              {status === 'submitting' ? 'Approving...' : 'Approve device'}
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/stockpro-web/src/pages/DevicePage.tsx
+++ b/stockpro-web/src/pages/DevicePage.tsx
@@ -27,13 +27,18 @@ export default function DevicePage() {
     }
     const body = await res.json().catch(() => ({}))
     const reason = body.error || 'unknown_error'
+    // If already approved, treat as success — the agent already has the token.
+    if (reason === 'already_approved') {
+      setStatus('approved')
+      return
+    }
     setError(
-      reason === 'unknown_code'
+      reason === 'unknown_code' || reason === 'invalid_code'
         ? 'That code is not valid. Check the code printed in your terminal.'
         : reason === 'expired'
           ? 'That code has expired. Start a new login from your agent.'
-          : reason === 'already_approved'
-            ? 'That code was already approved.'
+          : res.status >= 500
+            ? 'Server is temporarily busy. Please try again in a moment.'
             : 'Something went wrong. Try again.'
     )
     setStatus('error')

--- a/stockpro-web/src/pages/Settings.tsx
+++ b/stockpro-web/src/pages/Settings.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { useQuery, useMutation } from '@tanstack/react-query'
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { useUser } from '@clerk/clerk-react'
 import toast from 'react-hot-toast'
 import { useTranslation } from 'react-i18next'
@@ -28,8 +28,6 @@ const NAV_ITEMS = [
   { id: 'plan', icon: 'card_membership', tKey: 'settings.plan' },
   { id: 'danger', icon: 'warning', tKey: 'settings.dangerZone' },
 ]
-
-const CLI_SECTION_LABEL = 'CLI tokens'
 
 export default function Settings() {
   const { user } = useUser()

--- a/stockpro-web/src/pages/Settings.tsx
+++ b/stockpro-web/src/pages/Settings.tsx
@@ -24,9 +24,12 @@ const NAV_ITEMS = [
   { id: 'notifications', icon: 'notifications', tKey: 'settings.notifications' },
   { id: 'research', icon: 'query_stats', tKey: 'settings.researchDefaults' },
   { id: 'telegram', icon: 'send', tKey: 'settings.telegram' },
+  { id: 'cli', icon: 'terminal', tKey: 'settings.cli' },
   { id: 'plan', icon: 'card_membership', tKey: 'settings.plan' },
   { id: 'danger', icon: 'warning', tKey: 'settings.dangerZone' },
 ]
+
+const CLI_SECTION_LABEL = 'CLI tokens'
 
 export default function Settings() {
   const { user } = useUser()
@@ -299,6 +302,9 @@ export default function Settings() {
             </div>
           )}
 
+          {/* CLI TOKENS */}
+          {activeSection === 'cli' && <CliTokensSection />}
+
           {/* DANGER ZONE */}
           {activeSection === 'danger' && (
             <div style={{ background: 'rgba(239,68,68,0.08)', border: '1px solid rgba(239,68,68,0.2)', borderRadius: 14, overflow: 'hidden' }}>
@@ -322,6 +328,8 @@ export default function Settings() {
         </div>
       </main>
 
+      {/* CLI tokens section — intentionally outside the save-banner mutation flow */}
+
       {/* SAVE BANNER */}
       {hasChanges && (
         <div style={{ position: 'fixed', bottom: 0, left: 0, right: 0, zIndex: 50, display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 12, padding: '16px 24px', background: 'rgba(12,10,9,0.96)', backdropFilter: 'blur(16px)', borderTop: '1px solid #292524' }}>
@@ -334,6 +342,118 @@ export default function Settings() {
           </button>
         </div>
       )}
+    </div>
+  )
+}
+
+function CliTokensSection() {
+  const api = useApiClient()
+  const queryClient = useQueryClient()
+  const [newName, setNewName] = useState('')
+  const [newToken, setNewToken] = useState<string | null>(null)
+
+  const { data } = useQuery({
+    queryKey: ['cli-tokens'],
+    queryFn: async () => {
+      const res = await api.get('/api/tokens')
+      if (!res.ok) throw new Error('Failed to load tokens')
+      return res.json() as Promise<{ tokens: Array<{ id: string; name: string; prefix: string; created_at: string; last_used_at: string | null }> }>
+    },
+  })
+
+  const createMutation = useMutation({
+    mutationFn: async () => {
+      const res = await api.post('/api/tokens', { name: newName || 'CLI token' })
+      if (!res.ok) throw new Error('Failed to create token')
+      return res.json() as Promise<{ id: string; access_token: string }>
+    },
+    onSuccess: (resp) => {
+      setNewToken(resp.access_token)
+      setNewName('')
+      queryClient.invalidateQueries({ queryKey: ['cli-tokens'] })
+    },
+    onError: () => toast.error('Failed to create token'),
+  })
+
+  const revokeMutation = useMutation({
+    mutationFn: async (id: string) => {
+      const res = await api.delete(`/api/tokens/${id}`)
+      if (!res.ok) throw new Error('Failed to revoke')
+    },
+    onSuccess: () => {
+      toast.success('Token revoked')
+      queryClient.invalidateQueries({ queryKey: ['cli-tokens'] })
+    },
+    onError: () => toast.error('Failed to revoke token'),
+  })
+
+  const tokens = data?.tokens ?? []
+  const rowStyle = { display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '14px 20px', borderBottom: '1px solid #292524', gap: 16 } as const
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+      <p style={{ fontSize: 13, color: '#a8a29e', margin: 0 }}>
+        Long-lived tokens for the <code style={{ color: '#d6d3d1' }}>stockpro</code> CLI and headless agents. Set the token as <code style={{ color: '#d6d3d1' }}>STOCKPRO_TOKEN</code> or run <code style={{ color: '#d6d3d1' }}>stockpro auth device-login</code>.
+      </p>
+
+      {newToken && (
+        <div style={{ background: '#1c1917', border: '1px solid #22c55e', borderRadius: 12, padding: 16, display: 'flex', flexDirection: 'column', gap: 8 }}>
+          <div style={{ fontSize: 13, fontWeight: 600, color: '#22c55e' }}>Copy this token now</div>
+          <div style={{ fontSize: 12, color: '#a8a29e' }}>It will never be shown again.</div>
+          <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+            <code style={{ flex: 1, background: '#0c0a09', border: '1px solid #292524', borderRadius: 8, padding: '10px 12px', fontFamily: 'ui-monospace, monospace', fontSize: 12, color: '#fafaf9', wordBreak: 'break-all' }}>{newToken}</code>
+            <button
+              onClick={() => { navigator.clipboard.writeText(newToken); toast.success('Copied') }}
+              style={{ padding: '10px 14px', borderRadius: 8, border: '1px solid #292524', background: '#232120', color: '#fafaf9', fontSize: 12.5, fontWeight: 500, cursor: 'pointer' }}
+            >
+              Copy
+            </button>
+          </div>
+          <button onClick={() => setNewToken(null)} style={{ alignSelf: 'start', background: 'transparent', border: 0, color: '#a8a29e', fontSize: 12, cursor: 'pointer', marginTop: 4, padding: 0 }}>
+            I saved it
+          </button>
+        </div>
+      )}
+
+      <div style={{ background: '#1c1917', border: '1px solid #292524', borderRadius: 14, padding: 16, display: 'flex', gap: 8 }}>
+        <input
+          placeholder="Token name (e.g. laptop, serverless agent)"
+          value={newName}
+          onChange={e => setNewName(e.target.value)}
+          style={{ flex: 1, background: '#232120', border: '1px solid #292524', borderRadius: 8, color: '#fafaf9', fontSize: 13, padding: '9px 12px', outline: 'none' }}
+        />
+        <button
+          onClick={() => createMutation.mutate()}
+          disabled={createMutation.isPending}
+          style={{ padding: '9px 16px', borderRadius: 8, border: 'none', background: '#d6d3d1', color: '#0c0a09', fontSize: 13, fontWeight: 600, cursor: 'pointer' }}
+        >
+          {createMutation.isPending ? 'Creating...' : 'Create token'}
+        </button>
+      </div>
+
+      <div style={{ background: '#1c1917', border: '1px solid #292524', borderRadius: 14, overflow: 'hidden' }}>
+        {tokens.length === 0 ? (
+          <div style={{ padding: 20, fontSize: 13, color: '#a8a29e', textAlign: 'center' }}>No tokens yet. Create one above, or run <code>stockpro auth device-login</code>.</div>
+        ) : (
+          tokens.map((t, i) => (
+            <div key={t.id} style={{ ...rowStyle, borderBottom: i < tokens.length - 1 ? '1px solid #292524' : 'none' }}>
+              <div style={{ minWidth: 0, flex: 1 }}>
+                <div style={{ fontSize: 14, fontWeight: 500 }}>{t.name}</div>
+                <div style={{ fontSize: 12, color: '#a8a29e', marginTop: 3, fontFamily: 'ui-monospace, monospace' }}>
+                  {t.prefix}... &middot; created {new Date(t.created_at).toLocaleDateString()}
+                  {t.last_used_at && ` \u00B7 last used ${new Date(t.last_used_at).toLocaleDateString()}`}
+                </div>
+              </div>
+              <button
+                onClick={() => { if (confirm(`Revoke ${t.name}?`)) revokeMutation.mutate(t.id) }}
+                style={{ padding: '7px 14px', borderRadius: 8, border: '1px solid rgba(239,68,68,0.2)', background: 'rgba(239,68,68,0.08)', color: '#ef4444', fontSize: 12.5, fontWeight: 500, cursor: 'pointer' }}
+              >
+                Revoke
+              </button>
+            </div>
+          ))
+        )}
+      </div>
     </div>
   )
 }

--- a/stockpro-web/src/pages/SignIn.tsx
+++ b/stockpro-web/src/pages/SignIn.tsx
@@ -1,7 +1,11 @@
 import { SignIn as ClerkSignIn } from '@clerk/clerk-react'
+import { useSearchParams } from 'react-router'
 import Icon from '../components/Icon'
 
 export default function SignIn() {
+  const [params] = useSearchParams()
+  const redirectParam = params.get('redirect_url')
+  const afterSignIn = redirectParam || `${import.meta.env.BASE_URL}home`
   return (
     <div style={{ minHeight: '100vh', display: 'grid', gridTemplateColumns: '1fr 1fr' }}>
       {/* Left branding panel */}
@@ -85,7 +89,8 @@ export default function SignIn() {
           routing="path"
           path={`${import.meta.env.BASE_URL}sign-in`}
           signUpUrl={`${import.meta.env.BASE_URL}sign-up`}
-          afterSignInUrl={`${import.meta.env.BASE_URL}home`}
+          afterSignInUrl={afterSignIn}
+          forceRedirectUrl={afterSignIn}
           appearance={{
             variables: {
               colorBackground: '#1c1917',


### PR DESCRIPTION
## Summary
- Device-code auth flow (RFC 8628 style) so headless agents can authenticate — agent prints code, user approves in any browser
- `STOCKPRO_TOKEN` env var precedence so serverless agents can skip the device flow entirely
- Settings → CLI tokens page for manual token generation/revocation
- Two new tables (`api_keys`, `device_codes`) with RLS
- `login_required` decorator now accepts `Bearer sp_...` tokens alongside Clerk JWTs

## Test plan
- [x] `POST /api/device/authorize` returns device_code, user_code, https verification_uri
- [x] `POST /api/device/token` returns `{"status":"pending"}` for unapproved codes
- [ ] Full device-login flow end-to-end (agent polls, user approves, agent gets token)
- [ ] Create token in Settings UI → use as `STOCKPRO_TOKEN` → CLI command works
- [ ] Revoke token → next CLI call returns 401