### PR TITLE
feat: TASE (Tel Aviv Stock Exchange) multi-currency support

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -2098,6 +2098,7 @@ def portfolios_prices():
                     "market_value": to_float(h.get("market_value")),
                     "unrealized_gain": to_float(h.get("unrealized_gain")),
                     "unrealized_gain_pct": to_float(h.get("unrealized_gain_pct")),
+                    "currency": h.get("currency", "USD"),
                 })
             row["holdings"] = holdings_out
             row["day_change"] = day_change
@@ -2162,7 +2163,11 @@ def portfolio_prices(portfolio_id):
         return float(v) if v is not None else None
 
     holdings_out = []
+    has_ils = False
     for h in summary["holdings"]:
+        cur = h.get("currency", "USD")
+        if cur == "ILS":
+            has_ils = True
         holdings_out.append(
             {
                 "symbol": h["symbol"],
@@ -2174,29 +2179,32 @@ def portfolio_prices(portfolio_id):
                 "market_value": to_float(h.get("market_value")),
                 "unrealized_gain": to_float(h.get("unrealized_gain")),
                 "unrealized_gain_pct": to_float(h.get("unrealized_gain_pct")),
+                "currency": cur,
             }
         )
 
-    return jsonify(
-        {
-            "holdings": holdings_out,
-            "total_market_value": to_float(summary.get("total_market_value")),
-            "total_unrealized_gain": to_float(summary.get("total_unrealized_gain")),
-            "total_unrealized_gain_pct": to_float(
-                summary.get("total_unrealized_gain_pct")
-            ),
-            "stock_allocation_pct": to_float(summary.get("stock_allocation_pct")),
-            "crypto_allocation_pct": to_float(summary.get("crypto_allocation_pct")),
-            "track_cash": bool(summary.get("track_cash")),
-            "cash_balance": to_float(summary.get("cash_balance")),
-            "cash_allocation_pct": to_float(summary.get("cash_allocation_pct")),
-            "breakdowns": {
-                "sector": breakdowns.get("sector", []),
-                "market": breakdowns.get("market", []),
-                "prices_loaded": bool(breakdowns.get("prices_loaded")),
-            },
-        }
-    )
+    resp = {
+        "holdings": holdings_out,
+        "total_market_value": to_float(summary.get("total_market_value")),
+        "total_unrealized_gain": to_float(summary.get("total_unrealized_gain")),
+        "total_unrealized_gain_pct": to_float(
+            summary.get("total_unrealized_gain_pct")
+        ),
+        "stock_allocation_pct": to_float(summary.get("stock_allocation_pct")),
+        "crypto_allocation_pct": to_float(summary.get("crypto_allocation_pct")),
+        "track_cash": bool(summary.get("track_cash")),
+        "cash_balance": to_float(summary.get("cash_balance")),
+        "cash_allocation_pct": to_float(summary.get("cash_allocation_pct")),
+        "breakdowns": {
+            "sector": breakdowns.get("sector", []),
+            "market": breakdowns.get("market", []),
+            "prices_loaded": bool(breakdowns.get("prices_loaded")),
+        },
+    }
+    if has_ils:
+        from currency_utils import get_usd_ils_rate
+        resp["fx_rates"] = {"ILS_USD": to_float(Decimal("1") / get_usd_ils_rate())}
+    return jsonify(resp)
 
 
 @app.route("/api/portfolio/<portfolio_id>/history")
@@ -3489,23 +3497,37 @@ def api_ticker_fundamentals(symbol: str):
 
     try:
         info = yf.Ticker(symbol.upper()).info
+        raw_currency = info.get("currency", "USD")
+        if raw_currency == "ILA":
+            currency = "ILS"
+            ila_convert = lambda v: v / 100 if v is not None else None
+        else:
+            currency = raw_currency if raw_currency else "USD"
+            ila_convert = lambda v: v
+
+        current_price = _safe(info.get("currentPrice") or info.get("regularMarketPrice"))
+        w52_high = _safe(info.get("fiftyTwoWeekHigh"))
+        w52_low = _safe(info.get("fiftyTwoWeekLow"))
+
         return jsonify({
             "success": True,
             "symbol": symbol.upper(),
             "name": info.get("longName") or info.get("shortName"),
             "sector": info.get("sector"),
             "industry": info.get("industry"),
+            "exchange": info.get("exchange"),
+            "currency": currency,
             "market_cap": _safe(info.get("marketCap")),
             "pe_ratio": _safe(info.get("trailingPE")),
             "eps": _safe(info.get("trailingEps")),
             "revenue": _safe(info.get("totalRevenue")),
             "gross_margin": _safe(info.get("grossMargins")),
-            "week_52_high": _safe(info.get("fiftyTwoWeekHigh")),
-            "week_52_low": _safe(info.get("fiftyTwoWeekLow")),
+            "week_52_high": _safe(ila_convert(w52_high)),
+            "week_52_low": _safe(ila_convert(w52_low)),
             "avg_volume": _safe(info.get("averageVolume")),
             "beta": _safe(info.get("beta")),
             "dividend_yield": _safe(info.get("dividendYield")),
-            "current_price": _safe(info.get("currentPrice") or info.get("regularMarketPrice")),
+            "current_price": _safe(ila_convert(current_price)),
         })
     except Exception as e:
         return jsonify({"success": False, "error": str(e)}), 500
@@ -3539,6 +3561,7 @@ def api_ticker_search():
                 "name": c.get("display_name", q),
                 "price": float(c["price"]) if c.get("price") else None,
                 "change_pct": float(c["change_percent"]) if c.get("change_percent") else None,
+                "currency": c.get("currency", "USD"),
             })
     except Exception:
         pass
@@ -3549,6 +3572,10 @@ def api_ticker_search():
         name = info.get("longName") or info.get("shortName") or q
         price = info.get("currentPrice") or info.get("regularMarketPrice")
         change_pct = info.get("regularMarketChangePercent")
+        raw_currency = info.get("currency", "USD")
+        currency = "ILS" if raw_currency == "ILA" else (raw_currency or "USD")
+        if raw_currency == "ILA" and price:
+            price = price / 100
         if not name or name == q:
             return jsonify({"success": True, "valid": False, "symbol": q})
         return jsonify({
@@ -3558,6 +3585,7 @@ def api_ticker_search():
             "name": name,
             "price": float(price) if price else None,
             "change_pct": float(change_pct) if change_pct else None,
+            "currency": currency,
         })
     except Exception as e:
         return jsonify({"success": False, "error": str(e)}), 500

--- a/src/currency_utils.py
+++ b/src/currency_utils.py
@@ -1,0 +1,54 @@
+"""
+Currency utilities for TASE (Tel Aviv Stock Exchange) support.
+Handles ILA/ILS conversion and USD/ILS exchange rates.
+"""
+
+import logging
+import time
+from decimal import Decimal
+
+logger = logging.getLogger(__name__)
+
+_fx_cache: dict = {}
+_FX_TTL_SECONDS = 900  # 15 minutes
+_FALLBACK_USD_ILS = Decimal("3.6")
+
+
+def is_tase_ticker(symbol: str) -> bool:
+    return symbol.upper().endswith(".TA")
+
+
+def detect_currency(symbol: str) -> str:
+    return "ILS" if is_tase_ticker(symbol) else "USD"
+
+
+def ila_to_ils(price: Decimal) -> Decimal:
+    return price / 100
+
+
+def get_usd_ils_rate() -> Decimal:
+    cached = _fx_cache.get("USDILS")
+    if cached and time.time() - cached["ts"] < _FX_TTL_SECONDS:
+        return cached["rate"]
+
+    try:
+        import yfinance as yf
+
+        rate = yf.Ticker("USDILS=X").fast_info.last_price
+        if rate and rate > 0:
+            result = Decimal(str(rate))
+            _fx_cache["USDILS"] = {"rate": result, "ts": time.time()}
+            return result
+    except Exception:
+        logger.warning("Failed to fetch USD/ILS rate, using fallback")
+
+    return _FALLBACK_USD_ILS
+
+
+def convert_to_usd(amount: Decimal, currency: str) -> Decimal:
+    if currency == "USD":
+        return amount
+    if currency == "ILS":
+        rate = get_usd_ils_rate()
+        return amount / rate
+    return amount

--- a/src/data_providers/stock_provider.py
+++ b/src/data_providers/stock_provider.py
@@ -95,16 +95,28 @@ class StockDataProvider(BaseDataProvider):
 
     def _get_price_from_yfinance(self, symbol: str) -> dict:
         """yfinance lookup for current price and change%. Fast, no API key needed."""
-        result = {"price": None, "change_percent": None}
+        result = {"price": None, "change_percent": None, "currency": "USD"}
         try:
             import yfinance as yf
 
-            fi = yf.Ticker(symbol).fast_info
+            ticker = yf.Ticker(symbol)
+            fi = ticker.fast_info
             last = fi.last_price
             if last:
+                currency = getattr(fi, "currency", None) or "USD"
+                if currency == "ILA":
+                    last = last / 100
+                    result["currency"] = "ILS"
+                elif currency == "ILS":
+                    result["currency"] = "ILS"
+                else:
+                    result["currency"] = "USD"
+
                 result["price"] = Decimal(str(last))
                 prev = fi.regular_market_previous_close
                 if prev and prev > 0:
+                    if currency == "ILA":
+                        prev = prev / 100
                     pct = (last - prev) / prev * 100
                     result["change_percent"] = Decimal(str(round(pct, 4)))
         except Exception:
@@ -217,7 +229,7 @@ class StockDataProvider(BaseDataProvider):
     def _fetch_price_waterfall(self, symbol: str) -> dict:
         """
         Canonical waterfall: yfinance → concurrent(Nimble MW + SA) → Alpha Vantage.
-        Returns {'price': Decimal|None, 'change_percent': Decimal|None}.
+        Returns {'price': Decimal|None, 'change_percent': Decimal|None, 'currency': str}.
         """
         from concurrent.futures import ThreadPoolExecutor, as_completed
 

--- a/src/database.py
+++ b/src/database.py
@@ -424,6 +424,9 @@ class DatabaseManager:
                 cur.execute(
                     "CREATE INDEX IF NOT EXISTS idx_price_cache_last_updated ON price_cache (last_updated)"
                 )
+                cur.execute(
+                    "ALTER TABLE price_cache ADD COLUMN IF NOT EXISTS currency VARCHAR(3) DEFAULT 'USD'"
+                )
 
                 # Price alerts (user-defined targets vs cached quotes; evaluation in jobs later)
                 cur.execute("""
@@ -2079,22 +2082,23 @@ class DatabaseManager:
     # ── Price Cache ──────────────────────────────────────────────
 
     def upsert_price_cache(
-        self, symbol, asset_type, price, change_percent, display_name=None
+        self, symbol, asset_type, price, change_percent, display_name=None, currency="USD"
     ):
         conn = self.get_connection()
         try:
             with conn.cursor() as cur:
                 cur.execute(
                     """
-                    INSERT INTO price_cache (symbol, asset_type, price, change_percent, display_name, last_updated)
-                    VALUES (%s, %s, %s, %s, %s, NOW())
+                    INSERT INTO price_cache (symbol, asset_type, price, change_percent, display_name, currency, last_updated)
+                    VALUES (%s, %s, %s, %s, %s, %s, NOW())
                     ON CONFLICT (symbol) DO UPDATE SET
                         price          = EXCLUDED.price,
                         change_percent = EXCLUDED.change_percent,
                         display_name   = COALESCE(EXCLUDED.display_name, price_cache.display_name),
+                        currency       = EXCLUDED.currency,
                         last_updated   = NOW()
                 """,
-                    (symbol, asset_type, price, change_percent, display_name),
+                    (symbol, asset_type, price, change_percent, display_name, currency),
                 )
             conn.commit()
         finally:

--- a/src/portfolio/portfolio_service.py
+++ b/src/portfolio/portfolio_service.py
@@ -273,15 +273,19 @@ class PortfolioService:
             ).start()
 
         # Apply prices to holdings
+        from currency_utils import detect_currency, convert_to_usd
+
         for h in stocks:
             price = price_map.get(h["symbol"])
             h["current_price"] = price if price is not None else Decimal("0")
             h["price_available"] = price is not None
+            h["currency"] = detect_currency(h["symbol"])
 
         for h in cryptos:
             price = price_map.get(h["symbol"])
             h["current_price"] = price if price is not None else Decimal("0")
             h["price_available"] = price is not None
+            h["currency"] = "USD"
 
         # Calculate market value and gains for all holdings
         for h in holdings:
@@ -604,8 +608,18 @@ class PortfolioService:
             total_cost_basis += cash_balance
 
         if with_prices:
+            from currency_utils import convert_to_usd
+
+            for h in holdings:
+                mv = h.get("market_value")
+                cur = h.get("currency", "USD")
+                if mv is not None and cur != "USD":
+                    h["market_value_usd"] = convert_to_usd(mv, cur)
+                else:
+                    h["market_value_usd"] = mv
+
             total_market_value = sum(
-                h.get("market_value") or Decimal("0") for h in holdings
+                h.get("market_value_usd") or Decimal("0") for h in holdings
             )
             if track_cash:
                 total_market_value += cash_balance
@@ -616,12 +630,12 @@ class PortfolioService:
                 else Decimal("0")
             )
             stock_value = sum(
-                h.get("market_value") or Decimal("0")
+                h.get("market_value_usd") or Decimal("0")
                 for h in holdings
                 if h["asset_type"] == "stock"
             )
             crypto_value = sum(
-                h.get("market_value") or Decimal("0")
+                h.get("market_value_usd") or Decimal("0")
                 for h in holdings
                 if h["asset_type"] == "crypto"
             )

--- a/src/price_cache_service.py
+++ b/src/price_cache_service.py
@@ -64,16 +64,19 @@ class PriceCacheService:
             for sym, data in fetched.items():
                 price = data.get("price")
                 if price is not None:
+                    currency = data.get("currency", "USD")
                     self.db.upsert_price_cache(
                         sym,
                         "stock",
                         float(price),
                         data.get("change_percent"),
                         display_names.get(sym),
+                        currency=currency,
                     )
                     result[sym] = {
                         "price": price,
                         "change_percent": data.get("change_percent"),
+                        "currency": currency,
                     }
 
         if cryptos:

--- a/src/watchlist/watchlist_service.py
+++ b/src/watchlist/watchlist_service.py
@@ -82,6 +82,7 @@ class WatchlistService:
             item["price"] = cache.get("price")
             item["change_percent"] = cache.get("change_percent")
             item["price_last_updated"] = cache.get("last_updated")
+            item["currency"] = cache.get("currency", "USD")
             return item
 
         items = [enrich(item) for item in items]

--- a/stockpro-web/src/components/ExchangePicker.tsx
+++ b/stockpro-web/src/components/ExchangePicker.tsx
@@ -1,0 +1,41 @@
+const EXCHANGES = [
+  { value: 'US', label: 'US' },
+  { value: 'TASE', label: 'TASE' },
+] as const
+
+export type Exchange = typeof EXCHANGES[number]['value']
+
+export function appendExchangeSuffix(symbol: string, exchange: Exchange): string {
+  const clean = symbol.replace(/\.TA$/i, '').toUpperCase()
+  return exchange === 'TASE' ? `${clean}.TA` : clean
+}
+
+export default function ExchangePicker({
+  value,
+  onChange,
+}: {
+  value: Exchange
+  onChange: (v: Exchange) => void
+}) {
+  return (
+    <select
+      value={value}
+      onChange={e => onChange(e.target.value as Exchange)}
+      style={{
+        background: '#1c1917',
+        border: '1px solid #292524',
+        borderRadius: 8,
+        padding: '8px 12px',
+        color: '#fafaf9',
+        fontSize: 14,
+        fontFamily: 'Inter, sans-serif',
+        cursor: 'pointer',
+        minWidth: 72,
+      }}
+    >
+      {EXCHANGES.map(ex => (
+        <option key={ex.value} value={ex.value}>{ex.label}</option>
+      ))}
+    </select>
+  )
+}

--- a/stockpro-web/src/pages/AddTransaction.tsx
+++ b/stockpro-web/src/pages/AddTransaction.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { useMutation } from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { Link, useNavigate, useParams } from 'react-router'
 import toast from 'react-hot-toast'
 import { useTranslation } from 'react-i18next'
@@ -7,15 +7,17 @@ import AppNav from '../components/AppNav'
 import Icon from '../components/Icon'
 import { useApiClient } from '../api/client'
 import { useBreakpoint } from '../hooks/useBreakpoint'
-
-const fmt = (n: number) => new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(n)
+import { formatCurrency } from '../utils/currency'
+import ExchangePicker, { appendExchangeSuffix, type Exchange } from '../components/ExchangePicker'
 
 export default function AddTransaction() {
   const { id } = useParams()
   const navigate = useNavigate()
   const api = useApiClient()
+  const queryClient = useQueryClient()
   const { isMobile } = useBreakpoint()
   const { t } = useTranslation()
+  const [exchange, setExchange] = useState<Exchange>('US')
   const [form, setForm] = useState({ symbol: '', type: 'BUY', shares: '', price: '', date: new Date().toISOString().split('T')[0] })
 
   const total = parseFloat(form.shares || '0') * parseFloat(form.price || '0')
@@ -23,7 +25,7 @@ export default function AddTransaction() {
   const mutation = useMutation({
     mutationFn: async () => {
       const res = await api.post(`/api/portfolio/${id}/transaction`, {
-        symbol: form.symbol.toUpperCase(),
+        symbol: appendExchangeSuffix(form.symbol, exchange),
         type: form.type,
         shares: parseFloat(form.shares),
         price: parseFloat(form.price),
@@ -33,6 +35,8 @@ export default function AddTransaction() {
       return res.json()
     },
     onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['portfolio', id] })
+      queryClient.invalidateQueries({ queryKey: ['portfolios'] })
       toast.success(t('transactions.toasts.added'))
       navigate(`/portfolio/${id}`)
     },
@@ -84,12 +88,18 @@ export default function AddTransaction() {
           <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
             <div>
               <label style={{ display: 'block', fontSize: 12, fontWeight: 500, color: '#a8a29e', marginBottom: 6, letterSpacing: '0.02em' }}>Ticker symbol</label>
-              <input
-                value={form.symbol}
-                onChange={e => setForm(f => ({ ...f, symbol: e.target.value.toUpperCase() }))}
-                placeholder="NVDA"
-                style={{ ...inputStyle, fontFamily: 'Nunito, "Secular One", Heebo, sans-serif', fontSize: 18, fontWeight: 700, letterSpacing: '0.02em' }}
-              />
+              <div style={{ display: 'flex', gap: 8 }}>
+                <input
+                  value={form.symbol}
+                  onChange={e => setForm(f => ({ ...f, symbol: e.target.value.toUpperCase() }))}
+                  placeholder={exchange === 'TASE' ? 'TEVA' : 'NVDA'}
+                  style={{ ...inputStyle, flex: 1, fontFamily: 'Nunito, "Secular One", Heebo, sans-serif', fontSize: 18, fontWeight: 700, letterSpacing: '0.02em' }}
+                />
+                <ExchangePicker value={exchange} onChange={setExchange} />
+              </div>
+              {exchange === 'TASE' && (
+                <span style={{ fontSize: 11, color: '#78716c', marginTop: 4, display: 'block' }}>Enter price in ILS (shekels)</span>
+              )}
             </div>
             <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 12 }}>
               <div>
@@ -97,7 +107,7 @@ export default function AddTransaction() {
                 <input type="number" value={form.shares} onChange={e => setForm(f => ({ ...f, shares: e.target.value }))} placeholder="0" min="0" step="0.0001" style={inputStyle} />
               </div>
               <div>
-                <label style={{ display: 'block', fontSize: 12, fontWeight: 500, color: '#a8a29e', marginBottom: 6 }}>Price per share ($)</label>
+                <label style={{ display: 'block', fontSize: 12, fontWeight: 500, color: '#a8a29e', marginBottom: 6 }}>Price per share ({exchange === 'TASE' ? '₪' : '$'})</label>
                 <input type="number" value={form.price} onChange={e => setForm(f => ({ ...f, price: e.target.value }))} placeholder="0.00" min="0" step="0.01" style={inputStyle} />
               </div>
             </div>
@@ -120,7 +130,7 @@ export default function AddTransaction() {
                 </div>
               </div>
               <div style={{ textAlign: 'end' }}>
-                <div style={{ fontFamily: 'Nunito, "Secular One", Heebo, sans-serif', fontSize: 22, fontWeight: 600 }}>{fmt(total)}</div>
+                <div style={{ fontFamily: 'Nunito, "Secular One", Heebo, sans-serif', fontSize: 22, fontWeight: 600 }}>{formatCurrency(total)}</div>
                 <div style={{ fontSize: 11, color: '#a8a29e', marginTop: 2 }}>Total {form.type === 'BUY' ? 'cost' : 'proceeds'}</div>
               </div>
             </div>

--- a/stockpro-web/src/pages/Alerts.tsx
+++ b/stockpro-web/src/pages/Alerts.tsx
@@ -8,6 +8,8 @@ import Skeleton from '../components/Skeleton'
 import { useApiClient } from '../api/client'
 import { useLanguage } from '../LanguageContext'
 import { useBreakpoint } from '../hooks/useBreakpoint'
+import { formatCurrency } from '../utils/currency'
+import ExchangePicker, { appendExchangeSuffix, type Exchange } from '../components/ExchangePicker'
 
 export default function Alerts() {
   const api = useApiClient()
@@ -15,9 +17,10 @@ export default function Alerts() {
   const { t } = useTranslation()
   const { lang } = useLanguage()
   const { isMobile } = useBreakpoint()
-  const fmt = (n: number) => new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(n)
+  const locale = lang === 'he' ? 'he-IL' : 'en-US'
+  const fmt = (n: number) => formatCurrency(n, 'USD', locale)
   const [showCreate, setShowCreate] = useState(false)
-  // API create fields: symbol, direction (above|below), target_price, asset_type (stock|crypto)
+  const [alertExchange, setAlertExchange] = useState<Exchange>('US')
   const [newAlert, setNewAlert] = useState({ symbol: '', direction: 'above', target: '', asset_type: 'stock' })
 
   const { data, isLoading } = useQuery({
@@ -57,7 +60,7 @@ export default function Alerts() {
     // POST /api/alerts with {symbol, direction, target_price, asset_type}
     mutationFn: async () => {
       const res = await api.post('/api/alerts', {
-        symbol: newAlert.symbol.toUpperCase(),
+        symbol: appendExchangeSuffix(newAlert.symbol, alertExchange),
         direction: newAlert.direction,
         target_price: parseFloat(newAlert.target),
         asset_type: newAlert.asset_type,
@@ -144,7 +147,10 @@ export default function Alerts() {
             <div style={{ display: 'grid', gridTemplateColumns: isMobile ? '1fr' : '1fr 1fr 1fr', gap: 12, marginBottom: 16 }}>
               <div>
                 <label style={{ display: 'block', fontSize: 12, color: '#a8a29e', marginBottom: 6 }}>{t('alerts.ticker')}</label>
-                <input value={newAlert.symbol} onChange={e => setNewAlert(a => ({ ...a, symbol: e.target.value.toUpperCase() }))} placeholder="NVDA" style={{ width: '100%', background: '#232120', border: '1px solid #292524', borderRadius: 8, padding: '9px 12px', color: '#fafaf9', fontFamily: 'Inter, Heebo, sans-serif', fontSize: 13, outline: 'none', boxSizing: 'border-box' }} />
+                <div style={{ display: 'flex', gap: 8 }}>
+                  <input value={newAlert.symbol} onChange={e => setNewAlert(a => ({ ...a, symbol: e.target.value.toUpperCase() }))} placeholder={alertExchange === 'TASE' ? 'TEVA' : 'NVDA'} style={{ flex: 1, background: '#232120', border: '1px solid #292524', borderRadius: 8, padding: '9px 12px', color: '#fafaf9', fontFamily: 'Inter, Heebo, sans-serif', fontSize: 13, outline: 'none', boxSizing: 'border-box' }} />
+                  <ExchangePicker value={alertExchange} onChange={setAlertExchange} />
+                </div>
               </div>
               <div>
                 <label style={{ display: 'block', fontSize: 12, color: '#a8a29e', marginBottom: 6 }}>{t('alerts.condition')}</label>

--- a/stockpro-web/src/pages/Analytics.tsx
+++ b/stockpro-web/src/pages/Analytics.tsx
@@ -6,13 +6,7 @@ import Icon from '../components/Icon'
 import { useApiClient } from '../api/client'
 import { useBreakpoint } from '../hooks/useBreakpoint'
 import { useLanguage } from '../LanguageContext'
-
-const fmt = (n: number) => new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(n)
-const fmtCompact = (n: number) => {
-  if (n >= 1000000) return `$${(n / 1000000).toFixed(1)}M`
-  if (n >= 1000) return `$${(n / 1000).toFixed(1)}K`
-  return `$${n.toFixed(0)}`
-}
+import { formatCurrency, formatCompact } from '../utils/currency'
 
 function LineChart({ data, dates, costBasis, gain = true, locale = 'en-US' }: { data: number[]; dates?: string[]; costBasis?: number[]; gain?: boolean; locale?: string }) {
   if (!data || data.length < 2) return <div style={{ height: 200, background: '#232120', borderRadius: 8 }} />
@@ -59,7 +53,7 @@ function LineChart({ data, dates, costBasis, gain = true, locale = 'en-US' }: { 
       {yTicks.map(({ val, y }) => (
         <g key={val}>
           <line x1={padLeft} y1={y} x2={w - padRight} y2={y} stroke="#292524" strokeWidth="1" />
-          <text x={padLeft - 8} y={y + 4} fill="#78716c" fontSize="10" textAnchor="end" fontFamily="Inter, Heebo, sans-serif">{fmtCompact(val)}</text>
+          <text x={padLeft - 8} y={y + 4} fill="#78716c" fontSize="10" textAnchor="end" fontFamily="Inter, Heebo, sans-serif">{formatCompact(val)}</text>
         </g>
       ))}
       {/* X labels */}
@@ -197,10 +191,10 @@ export default function Analytics() {
         {/* KPI STRIP */}
         <div style={{ display: 'grid', gridTemplateColumns: isMobile ? '1fr' : isTablet ? 'repeat(2, 1fr)' : 'repeat(4, 1fr)', gap: 1, background: '#292524', border: '1px solid #292524', borderRadius: 14, overflow: 'hidden', marginBottom: 24 }}>
           {[
-            { label: 'Total Value', val: analytics.total_value ? fmt(analytics.total_value) : '-', sub: '', subColor: '#a8a29e' },
-            { label: 'Total Return', val: analytics.total_return ? `${analytics.total_return >= 0 ? '+' : ''}${fmt(analytics.total_return)}` : '-', sub: analytics.return_pct != null ? `${analytics.return_pct >= 0 ? '+' : ''}${typeof analytics.return_pct === 'number' ? analytics.return_pct.toFixed(1) : analytics.return_pct}%` : '', subColor: analytics.total_return >= 0 ? '#22c55e' : '#ef4444' },
+            { label: 'Total Value', val: analytics.total_value ? formatCurrency(analytics.total_value) : '-', sub: '', subColor: '#a8a29e' },
+            { label: 'Total Return', val: analytics.total_return ? `${analytics.total_return >= 0 ? '+' : ''}${formatCurrency(analytics.total_return)}` : '-', sub: analytics.return_pct != null ? `${analytics.return_pct >= 0 ? '+' : ''}${typeof analytics.return_pct === 'number' ? analytics.return_pct.toFixed(1) : analytics.return_pct}%` : '', subColor: analytics.total_return >= 0 ? '#22c55e' : '#ef4444' },
             { label: 'Holdings', val: String(kpis.holdings_count ?? analytics.allocation.length), sub: 'positions tracked', subColor: '#a8a29e' },
-            { label: 'Cost Basis', val: analytics.cost_basis ? fmt(analytics.cost_basis) : '-', sub: 'Total invested', subColor: '#a8a29e' },
+            { label: 'Cost Basis', val: analytics.cost_basis ? formatCurrency(analytics.cost_basis) : '-', sub: 'Total invested', subColor: '#a8a29e' },
           ].map(({ label, val, sub, subColor }) => (
             <div key={label} style={{ background: '#1c1917', padding: '20px 24px' }}>
               <div style={{ fontSize: 11, fontWeight: 500, textTransform: 'uppercase', letterSpacing: '0.07em', color: '#a8a29e', marginBottom: 8 }}>{label}</div>
@@ -258,7 +252,7 @@ export default function Analytics() {
                     <div key={a.symbol} style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
                       <div style={{ width: 10, height: 10, borderRadius: 2, background: a.color, flexShrink: 0 }} />
                       <div style={{ flex: 1, fontSize: 13, fontWeight: 500 }}>{a.symbol}</div>
-                      <div style={{ fontSize: 13, fontVariantNumeric: 'tabular-nums', color: '#a8a29e' }}>{fmt(a.value)}</div>
+                      <div style={{ fontSize: 13, fontVariantNumeric: 'tabular-nums', color: '#a8a29e' }}>{formatCurrency(a.value)}</div>
                       <div style={{ fontSize: 13, fontVariantNumeric: 'tabular-nums', minWidth: 48, textAlign: 'end' }}>{a.pct}%</div>
                     </div>
                   ))}
@@ -285,7 +279,7 @@ export default function Analytics() {
                         +{Number(p.pnl_pct).toFixed(2)}%
                       </div>
                       <div style={{ fontSize: 11.5, color: '#a8a29e', fontVariantNumeric: 'tabular-nums' }}>
-                        +{fmt(p.pnl)}
+                        +{formatCurrency(p.pnl)}
                       </div>
                     </div>
                   </div>
@@ -310,7 +304,7 @@ export default function Analytics() {
                         {Number(p.pnl_pct).toFixed(2)}%
                       </div>
                       <div style={{ fontSize: 11.5, color: '#a8a29e', fontVariantNumeric: 'tabular-nums' }}>
-                        {fmt(p.pnl)}
+                        {formatCurrency(p.pnl)}
                       </div>
                     </div>
                   </div>

--- a/stockpro-web/src/pages/HoldingDetail.tsx
+++ b/stockpro-web/src/pages/HoldingDetail.tsx
@@ -7,8 +7,7 @@ import Icon from '../components/Icon'
 import { useApiClient } from '../api/client'
 import { useBreakpoint } from '../hooks/useBreakpoint'
 import { useLanguage } from '../LanguageContext'
-
-const fmt = (n: number) => new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(n)
+import { formatCurrency } from '../utils/currency'
 
 function LineChart({ data, gain = true }: { data: number[]; gain?: boolean }) {
   if (!data || data.length < 2) return <div style={{ height: 140, background: '#232120', borderRadius: 8 }} />
@@ -145,11 +144,11 @@ export default function HoldingDetail() {
                 <div style={{ display: 'flex', alignItems: 'flex-end', justifyContent: 'space-between' }}>
                   <div>
                     <div style={{ fontSize: 11, fontWeight: 500, textTransform: 'uppercase', letterSpacing: '0.07em', color: '#a8a29e', marginBottom: 6 }}>Market Value</div>
-                    <div style={{ fontFamily: 'Nunito, "Secular One", Heebo, sans-serif', fontSize: isMobile ? 24 : 32, fontWeight: 600, letterSpacing: '-0.03em' }}>{fmt(holding.market_value)}</div>
+                    <div style={{ fontFamily: 'Nunito, "Secular One", Heebo, sans-serif', fontSize: isMobile ? 24 : 32, fontWeight: 600, letterSpacing: '-0.03em' }}>{formatCurrency(holding.market_value, holding.currency ?? 'USD')}</div>
                   </div>
                   <div style={{ textAlign: 'end' }}>
                     <div style={{ fontSize: 15, fontWeight: 600, color: gain ? '#22c55e' : '#ef4444' }}>
-                      <bdi>{gain ? '+' : ''}{fmt(holding.pnl)}</bdi>
+                      <bdi>{gain ? '+' : ''}{formatCurrency(holding.pnl, holding.currency ?? 'USD')}</bdi>
                     </div>
                     <div style={{ fontSize: 12, color: gain ? '#22c55e' : '#ef4444' }}>
                       <bdi>{gain ? '+' : ''}{holding.pnl_pct}%</bdi> all time
@@ -178,10 +177,10 @@ export default function HoldingDetail() {
                     </div>
                     <div style={{ flex: 1 }}>
                       <div style={{ fontSize: 13, fontWeight: 600 }}>{t.type} {t.shares} shares</div>
-                      <div style={{ fontSize: 12, color: '#a8a29e' }}>@ {fmt(t.price)} each &nbsp;&middot;&nbsp; {t.date}</div>
+                      <div style={{ fontSize: 12, color: '#a8a29e' }}>@ {formatCurrency(t.price, holding.currency ?? 'USD')} each &nbsp;&middot;&nbsp; {t.date}</div>
                     </div>
                     <div style={{ textAlign: 'end' }}>
-                      <div style={{ fontVariantNumeric: 'tabular-nums', fontSize: 13, fontWeight: 500 }}>{fmt(t.total || t.shares * t.price)}</div>
+                      <div style={{ fontVariantNumeric: 'tabular-nums', fontSize: 13, fontWeight: 500 }}>{formatCurrency(t.total || t.shares * t.price, holding.currency ?? 'USD')}</div>
                     </div>
                     <button
                       onClick={() => confirm('Delete this transaction?') && deleteMutation.mutate(t.id)}
@@ -201,12 +200,12 @@ export default function HoldingDetail() {
             <div>
               {[
                 { label: 'Shares held', val: String(holding.shares) },
-                { label: 'Avg cost basis', val: fmt(holding.avg_cost) },
-                { label: 'Current price', val: fmt(holding.current_price) },
-                { label: 'Market value', val: fmt(holding.market_value) },
-                { label: 'Unrealized P&L', val: `${gain ? '+' : ''}${fmt(holding.pnl)}`, color: gain ? '#22c55e' : '#ef4444' },
+                { label: 'Avg cost basis', val: formatCurrency(holding.avg_cost, holding.currency ?? 'USD') },
+                { label: 'Current price', val: formatCurrency(holding.current_price, holding.currency ?? 'USD') },
+                { label: 'Market value', val: formatCurrency(holding.market_value, holding.currency ?? 'USD') },
+                { label: 'Unrealized P&L', val: `${gain ? '+' : ''}${formatCurrency(holding.pnl, holding.currency ?? 'USD')}`, color: gain ? '#22c55e' : '#ef4444' },
                 { label: 'Return', val: `${gain ? '+' : ''}${holding.pnl_pct}%`, color: gain ? '#22c55e' : '#ef4444' },
-                { label: 'Cost basis total', val: fmt(holding.shares * holding.avg_cost) },
+                { label: 'Cost basis total', val: formatCurrency(holding.shares * holding.avg_cost, holding.currency ?? 'USD') },
               ].map(({ label, val, color }) => (
                 <div key={label} style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '13px 20px', borderBottom: '1px solid rgba(41,37,36,0.5)' }}>
                   <span style={{ fontSize: 13, color: '#a8a29e' }}>{label}</span>

--- a/stockpro-web/src/pages/Home.tsx
+++ b/stockpro-web/src/pages/Home.tsx
@@ -8,6 +8,7 @@ import Icon from '../components/Icon'
 import { useApiClient } from '../api/client'
 import { useLanguage } from '../LanguageContext'
 import { useBreakpoint } from '../hooks/useBreakpoint'
+import { formatCurrency } from '../utils/currency'
 
 function Sparkline({ gain = true }: { gain?: boolean }) {
   const color = gain ? '#22c55e' : '#ef4444'
@@ -40,7 +41,7 @@ export default function Home() {
   const { lang } = useLanguage()
   const { isMobile } = useBreakpoint()
   const locale = lang === 'he' ? 'he-IL' : 'en-US'
-  const fmt = (n: number) => new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(n)
+  const fmt = (n: number, currency = 'USD') => formatCurrency(n, currency, locale)
   const [ticker, setTicker] = useState('')
   const [changeMode, setChangeMode] = useState<'D' | 'W'>('D')
 
@@ -283,11 +284,11 @@ export default function Home() {
                               </div>
                             </Link>
                           </td>
-                          {[shares, avgCost ? fmt(avgCost) : '-', mv ? fmt(mv) : '-'].map((v, i) => (
+                          {[shares, avgCost ? fmt(avgCost, h.currency ?? 'USD') : '-', mv ? fmt(mv, h.currency ?? 'USD') : '-'].map((v, i) => (
                             <td key={i} style={{ padding: '14px 0', borderBottom: '1px solid rgba(41,37,36,0.5)', fontSize: 13.5, textAlign: 'end', fontVariantNumeric: 'tabular-nums', color: '#fafaf9' }}>{v}</td>
                           ))}
                           <td style={{ padding: '14px 0', borderBottom: '1px solid rgba(41,37,36,0.5)', fontSize: 13.5, textAlign: 'end', fontVariantNumeric: 'tabular-nums', color: pnl >= 0 ? '#22c55e' : '#ef4444' }}>
-                            <bdi>{pnl >= 0 ? '+' : ''}{fmt(pnl)}</bdi>
+                            <bdi>{pnl >= 0 ? '+' : ''}{fmt(pnl, h.currency ?? 'USD')}</bdi>
                           </td>
                           <td style={{ padding: '14px 0', borderBottom: '1px solid rgba(41,37,36,0.5)', textAlign: 'end' }}>
                             <span style={{ display: 'inline-flex', alignItems: 'center', gap: 3, fontSize: 12, fontWeight: 500, padding: '3px 8px', borderRadius: 999, background: pnlPct >= 0 ? 'rgba(34,197,94,0.08)' : 'rgba(239,68,68,0.08)', color: pnlPct >= 0 ? '#22c55e' : '#ef4444', border: `1px solid ${pnlPct >= 0 ? 'rgba(34,197,94,0.2)' : 'rgba(239,68,68,0.2)'}` }}>
@@ -374,7 +375,7 @@ export default function Home() {
                       </div>
                     </div>
                     <div style={{ textAlign: 'end' }}>
-                      <div style={{ fontSize: 13, fontVariantNumeric: 'tabular-nums', color: '#fafaf9' }}>{fmt(w.price)}</div>
+                      <div style={{ fontSize: 13, fontVariantNumeric: 'tabular-nums', color: '#fafaf9' }}>{fmt(w.price, w.currency ?? 'USD')}</div>
                       <div style={{ fontSize: 11.5, fontVariantNumeric: 'tabular-nums', color: w.change_pct >= 0 ? '#22c55e' : '#ef4444' }}>
                         <bdi>{w.change_pct >= 0 ? '+' : ''}{w.change_pct}%</bdi>
                       </div>

--- a/stockpro-web/src/pages/PortfolioDetail.tsx
+++ b/stockpro-web/src/pages/PortfolioDetail.tsx
@@ -9,12 +9,7 @@ import Skeleton from '../components/Skeleton'
 import { useApiClient } from '../api/client'
 import { useLanguage } from '../LanguageContext'
 import { useBreakpoint } from '../hooks/useBreakpoint'
-
-const fmtCompact = (n: number) => {
-  if (n >= 1000000) return `$${(n / 1000000).toFixed(1)}M`
-  if (n >= 1000) return `$${(n / 1000).toFixed(1)}K`
-  return `$${n.toFixed(0)}`
-}
+import { formatCurrency, formatCompact } from '../utils/currency'
 
 const RANGES = ['1W', '1M', '3M', 'YTD', '1Y']
 
@@ -101,7 +96,7 @@ function LineChart({ data, dates, gain = true, loading = false, locale = 'en-US'
       {yTicks.map(({ val, y }) => (
         <g key={val}>
           <line x1={padLeft} y1={y} x2={w - padRight} y2={y} stroke="#292524" strokeWidth="1" />
-          <text x={padLeft - 8} y={y + 4} fill="#78716c" fontSize="10" textAnchor="end" fontFamily="Inter, Heebo, sans-serif">{fmtCompact(val)}</text>
+          <text x={padLeft - 8} y={y + 4} fill="#78716c" fontSize="10" textAnchor="end" fontFamily="Inter, Heebo, sans-serif">{formatCompact(val)}</text>
         </g>
       ))}
       {/* X labels */}
@@ -244,7 +239,7 @@ export default function PortfolioDetail() {
   const { isMobile } = useBreakpoint()
 
   const locale = lang === 'he' ? 'he-IL' : 'en-US'
-  const fmt = (n: number) => new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(n)
+  const fmt = (n: number, currency = 'USD') => formatCurrency(n, currency, locale)
 
   // /api/portfolio/<id>/history returns {history: [{date, value}], granularity}
   const { data: historyData, isLoading: historyLoading } = useQuery({
@@ -625,11 +620,11 @@ export default function PortfolioDetail() {
                         </Link>
                       </td>
                       <td style={{ padding: '14px 24px', borderBottom: '1px solid rgba(41,37,36,0.5)', textAlign: 'end', fontVariantNumeric: 'tabular-nums', color: '#fafaf9' }}>{Number(h.shares).toFixed(2)}</td>
-                      <td style={{ padding: '14px 24px', borderBottom: '1px solid rgba(41,37,36,0.5)', textAlign: 'end', fontVariantNumeric: 'tabular-nums', color: '#fafaf9' }}>{fmt(h.avg_cost)}</td>
-                      <td style={{ padding: '14px 24px', borderBottom: '1px solid rgba(41,37,36,0.5)', textAlign: 'end', fontVariantNumeric: 'tabular-nums', color: '#fafaf9' }}>{h.current_price != null ? fmt(h.current_price) : <span style={{ color: '#57534e' }}>--</span>}</td>
-                      <td style={{ padding: '14px 24px', borderBottom: '1px solid rgba(41,37,36,0.5)', textAlign: 'end', fontVariantNumeric: 'tabular-nums', color: '#fafaf9' }}>{fmt(h.market_value)}</td>
+                      <td style={{ padding: '14px 24px', borderBottom: '1px solid rgba(41,37,36,0.5)', textAlign: 'end', fontVariantNumeric: 'tabular-nums', color: '#fafaf9' }}>{fmt(h.avg_cost, h.currency ?? 'USD')}</td>
+                      <td style={{ padding: '14px 24px', borderBottom: '1px solid rgba(41,37,36,0.5)', textAlign: 'end', fontVariantNumeric: 'tabular-nums', color: '#fafaf9' }}>{h.current_price != null ? fmt(h.current_price, h.currency ?? 'USD') : <span style={{ color: '#57534e' }}>--</span>}</td>
+                      <td style={{ padding: '14px 24px', borderBottom: '1px solid rgba(41,37,36,0.5)', textAlign: 'end', fontVariantNumeric: 'tabular-nums', color: '#fafaf9' }}>{fmt(h.market_value, h.currency ?? 'USD')}</td>
                       <td style={{ padding: '14px 24px', borderBottom: '1px solid rgba(41,37,36,0.5)', textAlign: 'end', fontVariantNumeric: 'tabular-nums', color: h.pnl >= 0 ? '#22c55e' : '#ef4444' }}>
-                        <bdi>{h.pnl >= 0 ? '+' : ''}{fmt(h.pnl)}</bdi>
+                        <bdi>{h.pnl >= 0 ? '+' : ''}{fmt(h.pnl, h.currency ?? 'USD')}</bdi>
                       </td>
                       <td style={{ padding: '14px 24px', borderBottom: '1px solid rgba(41,37,36,0.5)', textAlign: 'end' }}>
                         <span style={{ display: 'inline-flex', fontSize: 12, fontWeight: 500, padding: '3px 8px', borderRadius: 999, background: h.pnl_pct >= 0 ? 'rgba(34,197,94,0.08)' : 'rgba(239,68,68,0.08)', color: h.pnl_pct >= 0 ? '#22c55e' : '#ef4444', border: `1px solid ${h.pnl_pct >= 0 ? 'rgba(34,197,94,0.2)' : 'rgba(239,68,68,0.2)'}` }}>

--- a/stockpro-web/src/pages/PortfolioList.tsx
+++ b/stockpro-web/src/pages/PortfolioList.tsx
@@ -7,6 +7,8 @@ import AppNav from '../components/AppNav'
 import Icon from '../components/Icon'
 import { useApiClient } from '../api/client'
 import { useBreakpoint } from '../hooks/useBreakpoint'
+import { useLanguage } from '../LanguageContext'
+import { formatCurrency } from '../utils/currency'
 
 function Sparkline({ gain = true }: { gain?: boolean }) {
   const color = gain ? '#22c55e' : '#ef4444'
@@ -115,8 +117,10 @@ export default function PortfolioList() {
   const navigate = useNavigate()
   const { t } = useTranslation()
   const { isMobile } = useBreakpoint()
+  const { lang } = useLanguage()
 
-  const fmt = (n: number) => new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(n)
+  const locale = lang === 'he' ? 'he-IL' : 'en-US'
+  const fmt = (n: number) => formatCurrency(n, 'USD', locale)
 
   const { data, isLoading } = useQuery({
     queryKey: ['portfolios'],

--- a/stockpro-web/src/pages/ResearchWizard.tsx
+++ b/stockpro-web/src/pages/ResearchWizard.tsx
@@ -10,6 +10,8 @@ import { useAuth } from '@clerk/clerk-react'
 import { useLanguage } from '../LanguageContext'
 import { useBreakpoint } from '../hooks/useBreakpoint'
 import { useResearchProgress } from '../ResearchProgressContext'
+import { formatCurrency } from '../utils/currency'
+import ExchangePicker, { appendExchangeSuffix, type Exchange } from '../components/ExchangePicker'
 
 const TRADE_TYPES = [
   { id: 'day', icon: 'bolt', iconStyle: 'bull', name: 'Day Trade', nameKey: 'research.dayTrade', descKey: 'research.dayTradeDesc' },
@@ -57,13 +59,15 @@ interface PopupData {
 export default function ResearchWizard() {
   const [searchParams] = useSearchParams()
   const [ticker, setTicker] = useState(searchParams.get('ticker') || '')
+  const [exchange, setExchange] = useState<Exchange>('US')
   const [tradeType, setTradeType] = useState<string | null>(null)
   const [tickerInfo, setTickerInfo] = useState<any>(null)
   const [phase, setPhase] = useState<Phase>('setup')
   const { t } = useTranslation()
   const { lang } = useLanguage()
   const { isMobile } = useBreakpoint()
-  const fmt = (n: number) => new Intl.NumberFormat(lang === 'he' ? 'he-IL' : 'en-US', { style: 'currency', currency: 'USD' }).format(n)
+  const locale = lang === 'he' ? 'he-IL' : 'en-US'
+  const fmt = (n: number) => formatCurrency(n, 'USD', locale)
 
   // Position pre-screen state
   const [positionData, setPositionData] = useState<any>(null)
@@ -94,12 +98,12 @@ export default function ResearchWizard() {
     if (!ticker || ticker.length < 1) { setTickerInfo(null); return }
     const timer = setTimeout(async () => {
       try {
-        const res = await api.get(`/api/ticker/search?q=${ticker.toUpperCase()}`)
+        const res = await api.get(`/api/ticker/search?q=${appendExchangeSuffix(ticker, exchange)}`)
         if (res.ok) setTickerInfo(await res.json())
       } catch {}
     }, 400)
     return () => clearTimeout(timer)
-  }, [ticker])
+  }, [ticker, exchange])
 
   // Call /popup_start and advance to subjects or questions phase
   const callPopupStart = async (posSummary: string, posGoal: string) => {
@@ -109,7 +113,7 @@ export default function ResearchWizard() {
       // Always send English name to the API regardless of display language
       const tradeTypeFullForApi = TRADE_TYPES.find(tt => tt.id === tradeType)?.name || tradeType || ''
       const formData = new FormData()
-      formData.append('ticker', ticker.toUpperCase())
+      formData.append('ticker', appendExchangeSuffix(ticker, exchange))
       formData.append('trade_type', tradeTypeFullForApi)
       formData.append('language', lang)
       if (posSummary) formData.append('position_summary', posSummary)
@@ -175,7 +179,7 @@ export default function ResearchWizard() {
   // Launch button clicked — check position first
   const launchMutation = useMutation({
     mutationFn: async () => {
-      const res = await api.get(`/api/position_check/${ticker.toUpperCase()}`)
+      const res = await api.get(`/api/position_check/${appendExchangeSuffix(ticker, exchange)}`)
       if (!res.ok) return { holding: false, positions: [] }
       return res.json()
     },
@@ -240,14 +244,15 @@ export default function ResearchWizard() {
             <input
               value={ticker}
               onChange={e => setTicker(e.target.value.toUpperCase())}
-              placeholder={t('research.enterTicker')}
+              placeholder={exchange === 'TASE' ? 'TEVA' : t('research.enterTicker')}
               style={{ flex: 1, background: 'transparent', border: 'none', outline: 'none', fontFamily: 'Nunito, "Secular One", Heebo, sans-serif', fontSize: 20, fontWeight: 600, color: '#fafaf9', letterSpacing: '0.02em' }}
             />
+            <ExchangePicker value={exchange} onChange={setExchange} />
             {tickerInfo && (
               <div style={{ display: 'flex', alignItems: 'center', gap: 10, flexShrink: 0, padding: '6px 14px', background: '#232120', border: '1px solid #292524', borderRadius: 8, fontSize: 13 }}>
                 <span style={{ fontWeight: 600, color: '#d6d3d1' }}>{tickerInfo.symbol}</span>
                 <span style={{ color: '#a8a29e' }}>{tickerInfo.name}</span>
-                {tickerInfo.price && <span style={{ fontVariantNumeric: 'tabular-nums' }}>${tickerInfo.price}</span>}
+                {tickerInfo.price && <span style={{ fontVariantNumeric: 'tabular-nums' }}>{tickerInfo.currency === 'ILS' ? '₪' : '$'}{tickerInfo.price}</span>}
                 {tickerInfo.change_pct !== undefined && (
                   <span style={{ color: tickerInfo.change_pct >= 0 ? '#22c55e' : '#ef4444' }}>
                     <bdi>{tickerInfo.change_pct >= 0 ? '+' : ''}{tickerInfo.change_pct}%</bdi>

--- a/stockpro-web/src/pages/TickerPage.tsx
+++ b/stockpro-web/src/pages/TickerPage.tsx
@@ -7,9 +7,7 @@ import Skeleton from '../components/Skeleton'
 import { useApiClient } from '../api/client'
 import { useBreakpoint } from '../hooks/useBreakpoint'
 import { useLanguage } from '../LanguageContext'
-
-const fmt = (n: number) => new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(n)
-const fmtCompact = (n: number) => new Intl.NumberFormat('en-US', { notation: 'compact', maximumFractionDigits: 1 }).format(n)
+import { formatCurrency, formatCompact } from '../utils/currency'
 
 const RANGES = ['1D', '1W', '1M', '3M', '1Y']
 
@@ -102,13 +100,13 @@ export default function TickerPage() {
   const industry = fundamentals.industry || ''
 
   const statItems = [
-    { label: 'Market Cap', val: fundamentals.market_cap ? fmtCompact(fundamentals.market_cap) : '-' },
+    { label: 'Market Cap', val: fundamentals.market_cap ? formatCompact(fundamentals.market_cap, fundamentals.currency ?? 'USD') : '-' },
     { label: 'P/E Ratio', val: fundamentals.pe_ratio != null ? `${Number(fundamentals.pe_ratio).toFixed(1)}x` : '-' },
-    { label: 'EPS (TTM)', val: fundamentals.eps != null ? `$${Number(fundamentals.eps).toFixed(2)}` : '-' },
-    { label: 'Revenue (TTM)', val: fundamentals.revenue ? fmtCompact(fundamentals.revenue) : '-' },
+    { label: 'EPS (TTM)', val: fundamentals.eps != null ? formatCurrency(Number(fundamentals.eps), fundamentals.currency ?? 'USD') : '-' },
+    { label: 'Revenue (TTM)', val: fundamentals.revenue ? formatCompact(fundamentals.revenue, fundamentals.currency ?? 'USD') : '-' },
     { label: 'Gross Margin', val: fundamentals.gross_margin != null ? `${(fundamentals.gross_margin * 100).toFixed(1)}%` : '-', highlight: fundamentals.gross_margin != null && fundamentals.gross_margin > 0.4 },
-    { label: '52W Range', val: fundamentals.week_52_high && fundamentals.week_52_low ? `$${Number(fundamentals.week_52_low).toFixed(0)} – $${Number(fundamentals.week_52_high).toFixed(0)}` : '-', small: true },
-    { label: 'Avg Volume', val: fundamentals.avg_volume ? fmtCompact(fundamentals.avg_volume) : '-' },
+    { label: '52W Range', val: fundamentals.week_52_high && fundamentals.week_52_low ? `${formatCurrency(Number(fundamentals.week_52_low), fundamentals.currency ?? 'USD')} – ${formatCurrency(Number(fundamentals.week_52_high), fundamentals.currency ?? 'USD')}` : '-', small: true },
+    { label: 'Avg Volume', val: fundamentals.avg_volume ? formatCompact(fundamentals.avg_volume, fundamentals.currency ?? 'USD') : '-' },
     { label: 'Beta', val: fundamentals.beta != null ? Number(fundamentals.beta).toFixed(2) : '-' },
     { label: 'Dividend', val: fundamentals.dividend_yield != null ? `${(fundamentals.dividend_yield * 100).toFixed(2)}%` : '-', muted: !fundamentals.dividend_yield },
   ]
@@ -139,6 +137,11 @@ export default function TickerPage() {
               <div>
                 <div style={{ fontSize: 15, color: '#a8a29e' }}>{name !== symbol ? name : ''}</div>
                 <div style={{ display: 'flex', gap: 6, marginTop: 4 }}>
+                  {fundamentals.exchange && (
+                    <span style={{ fontSize: 12, fontWeight: 600, padding: '4px 10px', borderRadius: 999, border: '1px solid #292524', color: '#d6d3d1', background: '#1c1917' }}>
+                      {fundamentals.exchange}
+                    </span>
+                  )}
                   {sector && (
                     <span style={{ fontSize: 12, fontWeight: 500, padding: '4px 10px', borderRadius: 999, border: '1px solid #292524', color: '#a8a29e', background: '#1c1917' }}>
                       {sector}
@@ -154,11 +157,11 @@ export default function TickerPage() {
             </div>
             <div style={{ display: 'flex', alignItems: 'flex-end', gap: 14 }}>
               <span style={{ fontFamily: 'Nunito, "Secular One", Heebo, sans-serif', fontSize: isMobile ? 32 : 44, fontWeight: 600, letterSpacing: '-0.04em', lineHeight: 1, fontVariantNumeric: 'tabular-nums' }}>
-                {price ? fmt(price) : '-'}
+                {price ? formatCurrency(price, fundamentals.currency ?? 'USD') : '-'}
               </span>
               <div style={{ display: 'flex', alignItems: 'center', gap: 6, paddingBottom: 6 }}>
                 <span style={{ fontSize: 18, fontWeight: 600, color: gain ? '#22c55e' : '#ef4444', fontVariantNumeric: 'tabular-nums' }}>
-                  <bdi>{gain ? '+' : ''}{fmt(changeAbs)}</bdi>
+                  <bdi>{gain ? '+' : ''}{formatCurrency(changeAbs, fundamentals.currency ?? 'USD')}</bdi>
                 </span>
                 <span style={{ fontSize: 15, fontWeight: 500, color: gain ? '#22c55e' : '#ef4444', fontVariantNumeric: 'tabular-nums' }}>
                   <bdi>({gain ? '+' : ''}{changePct}%)</bdi>
@@ -292,16 +295,16 @@ export default function TickerPage() {
                     </div>
                     <div>
                       <div style={{ fontSize: 10.5, textTransform: 'uppercase', letterSpacing: '0.06em', color: '#a8a29e', marginBottom: 4 }}>Mkt Value</div>
-                      <div style={{ fontFamily: 'Nunito, "Secular One", Heebo, sans-serif', fontSize: 20, fontWeight: 600 }}>{fmt(position.market_value)}</div>
+                      <div style={{ fontFamily: 'Nunito, "Secular One", Heebo, sans-serif', fontSize: 20, fontWeight: 600 }}>{formatCurrency(position.market_value, fundamentals.currency ?? 'USD')}</div>
                     </div>
                     <div>
                       <div style={{ fontSize: 10.5, textTransform: 'uppercase', letterSpacing: '0.06em', color: '#a8a29e', marginBottom: 4 }}>Avg Cost</div>
-                      <div style={{ fontSize: 15, fontWeight: 500, fontVariantNumeric: 'tabular-nums' }}>{fmt(position.avg_cost)}</div>
+                      <div style={{ fontSize: 15, fontWeight: 500, fontVariantNumeric: 'tabular-nums' }}>{formatCurrency(position.avg_cost, fundamentals.currency ?? 'USD')}</div>
                     </div>
                     <div>
                       <div style={{ fontSize: 10.5, textTransform: 'uppercase', letterSpacing: '0.06em', color: '#a8a29e', marginBottom: 4 }}>Total Return</div>
                       <div style={{ fontSize: 15, fontWeight: 500, fontVariantNumeric: 'tabular-nums', color: position.pnl >= 0 ? '#22c55e' : '#ef4444' }}>
-                        <bdi>{position.pnl >= 0 ? '+' : ''}{fmt(position.pnl)} ({position.pnl_pct >= 0 ? '+' : ''}{position.pnl_pct}%)</bdi>
+                        <bdi>{position.pnl >= 0 ? '+' : ''}{formatCurrency(position.pnl, fundamentals.currency ?? 'USD')} ({position.pnl_pct >= 0 ? '+' : ''}{position.pnl_pct}%)</bdi>
                       </div>
                     </div>
                   </div>

--- a/stockpro-web/src/pages/Watchlist.tsx
+++ b/stockpro-web/src/pages/Watchlist.tsx
@@ -9,10 +9,8 @@ import Skeleton from '../components/Skeleton'
 import { useApiClient } from '../api/client'
 import { useLanguage } from '../LanguageContext'
 import { useBreakpoint } from '../hooks/useBreakpoint'
-
-function fmtPrice(n: number | null | undefined, _locale: string) {
-  return n != null ? new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(n) : '—'
-}
+import { formatCurrency } from '../utils/currency'
+import ExchangePicker, { appendExchangeSuffix, type Exchange } from '../components/ExchangePicker'
 
 function ItemMenu({ item, watchlistId: _watchlistId, onClose }: { item: any; watchlistId: string; onClose: () => void }) {
   const api = useApiClient()
@@ -57,13 +55,16 @@ function AddSymbolRow({ watchlistId, onDone }: { watchlistId: string; onDone: ()
   const queryClient = useQueryClient()
   const { t } = useTranslation()
   const [symbol, setSymbol] = useState('')
+  const [exchange, setExchange] = useState<Exchange>('US')
   const inputRef = useRef<HTMLInputElement>(null)
 
   useEffect(() => { inputRef.current?.focus() }, [])
 
+  const finalSymbol = appendExchangeSuffix(symbol, exchange)
+
   const addMutation = useMutation({
-    mutationFn: () => api.post(`/api/watchlist/${watchlistId}/symbol`, { symbol: symbol.toUpperCase() }).then(r => { if (!r.ok) throw new Error() }),
-    onSuccess: () => { queryClient.invalidateQueries({ queryKey: ['watchlists'] }); toast.success(t('watchlist.toasts.added', { symbol: symbol.toUpperCase() })); onDone() },
+    mutationFn: () => api.post(`/api/watchlist/${watchlistId}/symbol`, { symbol: finalSymbol }).then(r => { if (!r.ok) throw new Error() }),
+    onSuccess: () => { queryClient.invalidateQueries({ queryKey: ['watchlists'] }); toast.success(t('watchlist.toasts.added', { symbol: finalSymbol })); onDone() },
     onError: () => toast.error(t('watchlist.toasts.addFailed')),
   })
 
@@ -78,9 +79,10 @@ function AddSymbolRow({ watchlistId, onDone }: { watchlistId: string; onDone: ()
             value={symbol}
             onChange={e => setSymbol(e.target.value.toUpperCase())}
             onKeyDown={e => { if (e.key === 'Enter') submit(); if (e.key === 'Escape') onDone() }}
-            placeholder={t('watchlist.tickerPlaceholder')}
+            placeholder={exchange === 'TASE' ? 'TEVA' : t('watchlist.tickerPlaceholder')}
             style={{ flex: 1, background: '#232120', border: '1px solid #292524', borderRadius: 8, padding: '7px 12px', color: '#fafaf9', fontFamily: 'Inter, Heebo, sans-serif', fontSize: 13, outline: 'none' }}
           />
+          <ExchangePicker value={exchange} onChange={setExchange} />
           <button
             onClick={submit}
             disabled={!symbol.trim() || addMutation.isPending}
@@ -206,7 +208,7 @@ export default function Watchlist() {
                         </Link>
                       </td>
                       <td style={{ padding: '14px 20px', borderBottom: '1px solid rgba(41,37,36,0.5)', textAlign: 'end', fontVariantNumeric: 'tabular-nums', fontSize: 13.5, color: '#fafaf9' }}>
-                        {item.price != null ? fmtPrice(item.price, locale) : '—'}
+                        {item.price != null ? formatCurrency(item.price, item.currency ?? 'USD', locale) : '---'}
                       </td>
                       <td style={{ padding: '14px 20px', borderBottom: '1px solid rgba(41,37,36,0.5)', textAlign: 'end' }}>
                         {item.change_pct != null ? (

--- a/stockpro-web/src/utils/currency.ts
+++ b/stockpro-web/src/utils/currency.ts
@@ -1,0 +1,11 @@
+export function formatCurrency(amount: number | null | undefined, currency = 'USD', locale = 'en-US'): string {
+  if (amount == null) return '---'
+  return new Intl.NumberFormat(locale, { style: 'currency', currency }).format(amount)
+}
+
+export function formatCompact(amount: number, currency = 'USD'): string {
+  const sym = currency === 'ILS' ? '₪' : '$'
+  if (amount >= 1_000_000) return `${sym}${(amount / 1_000_000).toFixed(1)}M`
+  if (amount >= 1_000) return `${sym}${(amount / 1_000).toFixed(1)}K`
+  return `${sym}${amount.toFixed(0)}`
+}


### PR DESCRIPTION
## Summary
- Adds `.TA` ticker detection, ILA→ILS conversion, and USD/ILS FX in `src/currency_utils.py`
- New `currency` column on `price_cache`; portfolio/watchlist/holding endpoints now propagate currency and FX rates
- `ExchangePicker` component (US/TASE) and `formatCurrency` util — ₪ symbol for ILS, $ for USD
- All portfolio, ticker, watchlist, alerts, analytics, and research-wizard pages updated to honor per-holding currency

Closes #59.

## Test plan
- [ ] Add a `.TA` holding and confirm price shown in ₪
- [ ] Mixed-currency portfolio totals convert correctly via FX
- [ ] US holdings still display in $ unchanged
- [ ] Research wizard accepts a TASE ticker via ExchangePicker