### PR TITLE
feat(cli): add --exchange flag and currency-aware output for TASE

### DIFF
--- a/stockpro-cli/stockpro_cli/commands/alerts.py
+++ b/stockpro-cli/stockpro_cli/commands/alerts.py
@@ -2,6 +2,7 @@
 
 import click
 from stockpro_cli.client import get_client
+from stockpro_cli.exchanges import EXCHANGES, apply_exchange_suffix
 from stockpro_cli.output import output
 
 
@@ -21,16 +22,17 @@ def list_alerts(ctx):
 
 
 @alerts.command("create")
-@click.option("--symbol", required=True, help="Ticker symbol")
+@click.option("--symbol", required=True, help="Ticker symbol (or symbol.TA for TASE)")
+@click.option("--exchange", default="US", type=click.Choice(EXCHANGES, case_sensitive=False), help="US (default) or TASE. TASE target prices must be in ILS.")
 @click.option("--direction", required=True, type=click.Choice(["above", "below"]))
 @click.option("--target-price", required=True, type=float)
 @click.option("--asset-type", default=None, help="stock or crypto")
 @click.pass_context
-def create_alert(ctx, symbol, direction, target_price, asset_type):
+def create_alert(ctx, symbol, exchange, direction, target_price, asset_type):
     """Create a new price alert."""
     client = get_client(ctx.obj.get("api_url"))
     payload = {
-        "symbol": symbol.upper(),
+        "symbol": apply_exchange_suffix(symbol, exchange),
         "direction": direction,
         "target_price": target_price,
     }

--- a/stockpro-cli/stockpro_cli/commands/portfolio.py
+++ b/stockpro-cli/stockpro_cli/commands/portfolio.py
@@ -2,6 +2,7 @@
 
 import click
 from stockpro_cli.client import get_client
+from stockpro_cli.exchanges import EXCHANGES, apply_exchange_suffix
 from stockpro_cli.output import output
 
 
@@ -32,18 +33,19 @@ def get_portfolio(ctx, portfolio_id):
 
 @portfolio.command("add-transaction")
 @click.option("--id", "portfolio_id", required=True, help="Portfolio ID")
-@click.option("--symbol", required=True, help="Ticker symbol")
+@click.option("--symbol", required=True, help="Ticker symbol (or symbol.TA for TASE)")
+@click.option("--exchange", default="US", type=click.Choice(EXCHANGES, case_sensitive=False), help="US (default) or TASE. TASE prices must be in ILS.")
 @click.option("--type", "tx_type", required=True, type=click.Choice(["buy", "sell"]))
 @click.option("--shares", required=True, type=float)
 @click.option("--price", required=True, type=float)
 @click.option("--date", default=None, help="Transaction date (YYYY-MM-DD)")
 @click.option("--notes", default=None)
 @click.pass_context
-def add_transaction(ctx, portfolio_id, symbol, tx_type, shares, price, date, notes):
+def add_transaction(ctx, portfolio_id, symbol, exchange, tx_type, shares, price, date, notes):
     """Add a buy/sell transaction."""
     client = get_client(ctx.obj.get("api_url"))
     payload = {
-        "symbol": symbol.upper(),
+        "symbol": apply_exchange_suffix(symbol, exchange),
         "type": tx_type,
         "shares": shares,
         "price": price,
@@ -121,10 +123,11 @@ def transactions(ctx, portfolio_id, limit):
 
 @portfolio.command("holding")
 @click.option("--id", "portfolio_id", required=True, help="Portfolio ID")
-@click.option("--symbol", required=True, help="Ticker symbol")
+@click.option("--symbol", required=True, help="Ticker symbol (or symbol.TA for TASE)")
+@click.option("--exchange", default="US", type=click.Choice(EXCHANGES, case_sensitive=False), help="US (default) or TASE")
 @click.pass_context
-def holding(ctx, portfolio_id, symbol):
+def holding(ctx, portfolio_id, symbol, exchange):
     """Get details for a specific holding."""
     client = get_client(ctx.obj.get("api_url"))
-    data = client.get(f"/api/portfolio/{portfolio_id}/holding/{symbol.upper()}")
+    data = client.get(f"/api/portfolio/{portfolio_id}/holding/{apply_exchange_suffix(symbol, exchange)}")
     output(data, ctx.obj.get("pretty", False))

--- a/stockpro-cli/stockpro_cli/commands/ticker.py
+++ b/stockpro-cli/stockpro_cli/commands/ticker.py
@@ -2,6 +2,7 @@
 
 import click
 from stockpro_cli.client import get_client
+from stockpro_cli.exchanges import EXCHANGES, apply_exchange_suffix
 from stockpro_cli.output import output
 
 
@@ -12,26 +13,28 @@ def ticker():
 
 
 @ticker.command("history")
-@click.option("--symbol", required=True, help="Ticker symbol")
+@click.option("--symbol", required=True, help="Ticker symbol (or symbol.TA for TASE)")
+@click.option("--exchange", default="US", type=click.Choice(EXCHANGES, case_sensitive=False), help="US (default) or TASE")
 @click.option("--range", "time_range", default=None, help="Time range (e.g. 1m, 3m, 1y)")
 @click.pass_context
-def history(ctx, symbol, time_range):
+def history(ctx, symbol, exchange, time_range):
     """Get price history for a ticker."""
     client = get_client(ctx.obj.get("api_url"))
     params = {}
     if time_range:
         params["range"] = time_range
-    data = client.get(f"/api/ticker/{symbol.upper()}/history", params=params)
+    data = client.get(f"/api/ticker/{apply_exchange_suffix(symbol, exchange)}/history", params=params)
     output(data, ctx.obj.get("pretty", False))
 
 
 @ticker.command("fundamentals")
-@click.option("--symbol", required=True, help="Ticker symbol")
+@click.option("--symbol", required=True, help="Ticker symbol (or symbol.TA for TASE)")
+@click.option("--exchange", default="US", type=click.Choice(EXCHANGES, case_sensitive=False), help="US (default) or TASE")
 @click.pass_context
-def fundamentals(ctx, symbol):
+def fundamentals(ctx, symbol, exchange):
     """Get fundamental data for a ticker."""
     client = get_client(ctx.obj.get("api_url"))
-    data = client.get(f"/api/ticker/{symbol.upper()}/fundamentals")
+    data = client.get(f"/api/ticker/{apply_exchange_suffix(symbol, exchange)}/fundamentals")
     output(data, ctx.obj.get("pretty", False))
 
 

--- a/stockpro-cli/stockpro_cli/commands/watchlist.py
+++ b/stockpro-cli/stockpro_cli/commands/watchlist.py
@@ -2,6 +2,7 @@
 
 import click
 from stockpro_cli.client import get_client
+from stockpro_cli.exchanges import EXCHANGES, apply_exchange_suffix
 from stockpro_cli.output import output
 
 
@@ -26,12 +27,13 @@ def list_watchlists(ctx, wl):
 
 @watchlist.command("add-symbol")
 @click.option("--id", "watchlist_id", required=True, help="Watchlist ID")
-@click.option("--symbol", required=True, help="Ticker symbol")
+@click.option("--symbol", required=True, help="Ticker symbol (or symbol.TA for TASE)")
+@click.option("--exchange", default="US", type=click.Choice(EXCHANGES, case_sensitive=False), help="US (default) or TASE")
 @click.pass_context
-def add_symbol(ctx, watchlist_id, symbol):
+def add_symbol(ctx, watchlist_id, symbol, exchange):
     """Add a symbol to a watchlist."""
     client = get_client(ctx.obj.get("api_url"))
-    data = client.post(f"/api/watchlist/{watchlist_id}/symbol", {"symbol": symbol.upper()})
+    data = client.post(f"/api/watchlist/{watchlist_id}/symbol", {"symbol": apply_exchange_suffix(symbol, exchange)})
     output(data, ctx.obj.get("pretty", False))
 
 

--- a/stockpro-cli/stockpro_cli/exchanges.py
+++ b/stockpro-cli/stockpro_cli/exchanges.py
@@ -1,0 +1,36 @@
+"""Exchange and currency helpers for CLI symbol input and formatted output."""
+
+EXCHANGES = ("US", "TASE")
+
+_SUFFIX = {
+    "US": "",
+    "TASE": ".TA",
+}
+
+_CURRENCY_SYMBOLS = {
+    "USD": "$",
+    "ILS": "₪",
+}
+
+
+def apply_exchange_suffix(symbol: str, exchange: str) -> str:
+    """Append the exchange suffix to a bare symbol if missing."""
+    sym = symbol.strip().upper()
+    suffix = _SUFFIX.get(exchange.upper(), "")
+    if not suffix or sym.endswith(suffix):
+        return sym
+    return f"{sym}{suffix}"
+
+
+def currency_symbol(currency: str | None) -> str:
+    """Return the printable symbol for an ISO currency code."""
+    if not currency:
+        return "$"
+    return _CURRENCY_SYMBOLS.get(currency.upper(), currency.upper() + " ")
+
+
+def format_money(amount: float | int | None, currency: str | None = "USD") -> str:
+    """Format an amount with the right currency symbol, e.g. $1,234.56 or ₪38.50."""
+    if amount is None:
+        return "-"
+    return f"{currency_symbol(currency)}{float(amount):,.2f}"

--- a/stockpro-cli/stockpro_cli/output.py
+++ b/stockpro-cli/stockpro_cli/output.py
@@ -3,6 +3,8 @@
 import json
 import sys
 
+from stockpro_cli.exchanges import currency_symbol
+
 
 def output(data, pretty: bool = False):
     if not pretty:
@@ -100,8 +102,9 @@ def _print_portfolios(data):
             mv = h.get("market_value", 0)
             ug = h.get("unrealized_gain", 0)
             ugp = h.get("unrealized_gain_pct", 0)
+            cs = currency_symbol(h.get("currency"))
             sign = "+" if ug >= 0 else ""
-            print(f"  {sym:<8} ${price:>9.2f} {qty:>8.2f} ${mv:>11,.2f} {sign}${ug:>10,.2f} {sign}{ugp:>6.1f}%")
+            print(f"  {sym:<8} {cs}{price:>9.2f} {qty:>8.2f} {cs}{mv:>11,.2f} {sign}{cs}{ug:>10,.2f} {sign}{ugp:>6.1f}%")
 
         print()
 
@@ -126,7 +129,8 @@ def _print_alerts(alerts):
         cp = a.get("current_price", 0)
         active = "yes" if a.get("active") else "no"
         aid = a.get("alert_id", a.get("id", "?"))[:8]
-        print(f"  {sym:<8} {d:<6} ${tp:>9.2f} ${cp:>9.2f} {active:>7}  {aid}...")
+        cs = currency_symbol(a.get("currency"))
+        print(f"  {sym:<8} {d:<6} {cs}{tp:>9.2f} {cs}{cp:>9.2f} {active:>7}  {aid}...")
 
 
 def _print_watchlist_active(wl):
@@ -149,8 +153,9 @@ def _print_watchlist_active(wl):
         price = float(item.get("price", 0))
         change = float(item.get("change_pct", 0))
         pinned = "yes" if item.get("is_pinned") else ""
+        cs = currency_symbol(item.get("currency"))
         sign = "+" if change >= 0 else ""
-        print(f"  {sym:<8} ${price:>9.2f} {sign}{change:>6.1f}%  {pinned}")
+        print(f"  {sym:<8} {cs}{price:>9.2f} {sign}{change:>6.1f}%  {pinned}")
 
 
 def _print_news(articles):
@@ -206,8 +211,9 @@ def _print_home(data):
             ug = h.get("unrealized_gain", 0)
             ugp = h.get("unrealized_gain_pct", 0)
             avg = h.get("average_cost", 0)
+            cs = currency_symbol(h.get("currency"))
             sign = "+" if ug >= 0 else ""
-            print(f"  {sym:<8} ${avg:>9.2f} ${mv:>11,.2f} {sign}${ug:>10,.2f} {sign}{ugp:>6.1f}%")
+            print(f"  {sym:<8} {cs}{avg:>9.2f} {cs}{mv:>11,.2f} {sign}{cs}{ug:>10,.2f} {sign}{ugp:>6.1f}%")
         print()
 
     # Watchlist preview
@@ -219,8 +225,9 @@ def _print_home(data):
             name = item.get("name", "")
             price = float(item.get("price", 0))
             change = float(item.get("change_pct", 0))
+            cs = currency_symbol(item.get("currency"))
             sign = "+" if change >= 0 else ""
-            print(f"  {sym:<8} ${price:>9.2f}  {sign}{change:.1f}%  {name}")
+            print(f"  {sym:<8} {cs}{price:>9.2f}  {sign}{change:.1f}%  {name}")
         print()
 
     # News


### PR DESCRIPTION
## Summary
Brings the CLI to parity with the SPA on TASE support.

- New `stockpro_cli/exchanges.py` with `apply_exchange_suffix` and `currency_symbol` helpers
- `--exchange [US|TASE]` flag on the symbol-taking commands: `portfolio add-transaction`, `portfolio holding`, `alerts create`, `watchlist add-symbol`, `ticker history`, `ticker fundamentals` (defaults to `US`, fully backward-compatible)
- Pretty-print output (portfolios, watchlist, alerts, home dashboard) reads each row's `currency` field and renders ILS as ₪, USD as \$

## Example
```
stockpro portfolio add-transaction --id <pid> --symbol TEVA --exchange TASE --type buy --shares 10 --price 38.50
```
Pretty output now mixes currencies row-by-row (NVDA in \$, TEVA.TA in ₪).

## Test plan
- [x] Helper unit-tested locally (suffix + symbol mapping)
- [x] `--help` for all six commands shows `--exchange`
- [x] Pretty output renders ₪ for ILS rows and \$ for USD rows in same portfolio
- [ ] Smoke-test against staging: add TEVA.TA, list portfolio