### PR TITLE
feat(billing): integrate Whop for paid Starter/Ultra tiers with webho…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -69,3 +69,13 @@ OPENAI_API_KEY=
 # --- ConvertKit (waitlist signups; optional for local dev) ---
 # CONVERTKIT_API_KEY=
 # CONVERTKIT_FORM_ID=
+
+# --- Whop (paid plans; required for billing in production) ---
+# Create Starter and Ultra products in Whop (each with monthly + yearly plans).
+# Each product has ONE checkout URL — Whop shows the cadence picker on its page.
+# URL looks like:  https://whop.com/<org-slug>/<product-slug>/
+# Webhook secret comes from Whop → Developer → Webhooks → "Add endpoint".
+WHOP_API_KEY=
+WHOP_WEBHOOK_SECRET=
+WHOP_STARTER_URL=
+WHOP_ULTRA_URL=

--- a/src/app.py
+++ b/src/app.py
@@ -2036,6 +2036,22 @@ def api_delete_transaction(portfolio_id: str, transaction_id: str):
 @login_required
 def api_create_portfolio():
     """Create a new portfolio (JSON API for React SPA)."""
+    import math as _math
+    from database import get_database_manager
+    from tiers import get_limit
+
+    uid = session["user_id"]
+    db = get_database_manager()
+    limit = get_limit(uid, "portfolios")
+    if limit != _math.inf and db.count_user_portfolios(uid) >= int(limit):
+        return jsonify({
+            "ok": False,
+            "error": "quota_exceeded",
+            "resource": "portfolios",
+            "limit": int(limit),
+            "message": f"Free plan allows {int(limit)} portfolio. Upgrade to add more.",
+        }), 402
+
     data = request.get_json(silent=True) or {}
     name = data.get("name", "").strip()
     if not name:
@@ -2344,8 +2360,22 @@ def api_create_alert():
     if asset_type not in ("stock", "crypto"):
         return jsonify({"success": False, "error": "invalid asset_type"}), 400
 
-    alert_id = str(uuid.uuid4())
+    import math as _math
+    from tiers import get_limit
+
+    uid = session["user_id"]
     db = get_database_manager()
+    limit = get_limit(uid, "price_alerts")
+    if limit != _math.inf and db.count_user_active_alerts(uid) >= int(limit):
+        return jsonify({
+            "success": False,
+            "error": "quota_exceeded",
+            "resource": "price_alerts",
+            "limit": int(limit),
+            "message": f"Your plan allows {int(limit)} active alerts. Upgrade to add more.",
+        }), 402
+
+    alert_id = str(uuid.uuid4())
     db.create_price_alert(
         alert_id=alert_id,
         user_id=session["user_id"],
@@ -2458,6 +2488,143 @@ def api_telegram_connect_token():
     return jsonify({"success": True, "token": token, "ttl_minutes": 10})
 
 
+# ==================== Billing (Whop) ====================
+
+
+@app.route("/api/billing/plans", methods=["GET"])
+def api_billing_plans():
+    """Public: tier plan IDs and prices for the SPA pricing page."""
+    from tiers import plans_public
+
+    return jsonify({"success": True, "plans": plans_public()})
+
+
+@app.route("/api/billing/checkout-session", methods=["POST"])
+@login_required
+def api_billing_checkout_session():
+    """Return a Whop hosted checkout URL with user_id/tier/cadence baked in.
+
+    SPA opens this URL in a new tab; on payment Whop fires `membership.activated`
+    with the metadata, which our webhook uses to link the user to a tier.
+    """
+    data = request.get_json(silent=True) or {}
+    tier = (data.get("tier") or "").strip().lower()
+
+    from tiers import build_checkout_url
+
+    url = build_checkout_url(tier, session["user_id"])
+    if not url:
+        return jsonify({"success": False, "error": "plan not configured"}), 400
+
+    return jsonify({"success": True, "checkout_url": url})
+
+
+@app.route("/api/billing/webhook", methods=["POST"])
+def api_billing_webhook():
+    """Whop webhook receiver. Verifies HMAC sig, updates DB."""
+    from billing.whop_service import verify_webhook, WhopSignatureError
+    from database import get_database_manager
+    from datetime import datetime, timezone
+
+    raw_body = request.get_data() or b""
+    try:
+        event = verify_webhook(raw_body, dict(request.headers))
+    except WhopSignatureError as e:
+        app.logger.warning("whop webhook rejected: %s", e)
+        return jsonify({"ok": False, "error": "signature"}), 401
+
+    event_type = (event.get("action") or event.get("type") or "").lower()
+    payload = event.get("data") or {}
+    membership_id = (
+        payload.get("id")
+        or payload.get("membership_id")
+        or payload.get("membership", {}).get("id")
+    )
+    plan_id = payload.get("plan_id") or payload.get("plan", {}).get("id")
+    metadata = payload.get("metadata") or {}
+    user_id = metadata.get("user_id")
+
+    db = get_database_manager()
+
+    # Look up the user_id from a previously-stored sub if metadata is missing
+    if not user_id and membership_id:
+        user_id = db.get_subscription_user(membership_id)
+
+    def _parse_period_end():
+        v = (
+            payload.get("expires_at")
+            or payload.get("renewal_period_end")
+            or payload.get("current_period_end")
+        )
+        if not v:
+            return None
+        try:
+            if isinstance(v, (int, float)):
+                return datetime.fromtimestamp(int(v), tz=timezone.utc)
+            return datetime.fromisoformat(str(v).replace("Z", "+00:00"))
+        except Exception:
+            return None
+
+    if event_type in ("membership.activated", "membership.went_valid", "membership_went_valid"):
+        # Tier comes from metadata on our checkout URL.
+        # Cadence we derive from the membership/plan fields Whop sends us.
+        from tiers import derive_cadence_from_webhook
+
+        tier = (metadata.get("tier") or "").lower()
+        cadence = derive_cadence_from_webhook(payload)
+        if not (user_id and membership_id):
+            return jsonify({"ok": False, "error": "missing user_id/membership_id"}), 400
+        if tier not in ("starter", "ultra"):
+            app.logger.warning("whop webhook: bad/missing tier metadata: %s", tier)
+            return jsonify({"ok": False, "error": "missing tier metadata"}), 400
+        db.upsert_subscription(
+            user_id=user_id,
+            whop_membership_id=membership_id,
+            whop_plan_id=plan_id or "",
+            tier=tier,
+            cadence=cadence,
+            status="active",
+            current_period_end=_parse_period_end(),
+        )
+        db.set_user_tier(user_id, tier)
+        return jsonify({"ok": True})
+
+    if event_type in ("membership.deactivated", "membership.cancelled", "membership_went_invalid"):
+        if membership_id:
+            db.set_subscription_status(membership_id, "canceled")
+        if user_id:
+            db.set_user_tier(user_id, "free")
+        return jsonify({"ok": True})
+
+    if event_type in ("payment.succeeded", "payment_succeeded"):
+        period_end = _parse_period_end()
+        if membership_id and period_end:
+            db.update_subscription_period_end(membership_id, period_end)
+        return jsonify({"ok": True})
+
+    if event_type in ("refund.created", "refund_created"):
+        if membership_id:
+            db.set_subscription_status(membership_id, "canceled")
+        if user_id:
+            db.set_user_tier(user_id, "free")
+        app.logger.info("whop refund processed for membership %s", membership_id)
+        return jsonify({"ok": True})
+
+    # Unknown event types: 200 so Whop doesn't retry forever
+    return jsonify({"ok": True, "ignored": event_type})
+
+
+# Some webhook handlers must NOT receive CSRF protection (Flask-WTF wraps
+# the app); make sure this one is exempt if csrf is initialized.
+try:
+    from flask_wtf.csrf import CSRFProtect  # noqa: F401
+    _csrf = app.extensions.get("csrf") if hasattr(app, "extensions") else None
+    if _csrf is not None and hasattr(_csrf, "exempt"):
+        _csrf.exempt(api_billing_webhook)
+except Exception:
+    pass
+
+
 @app.route("/api/settings", methods=["GET"])
 @login_required
 def api_settings_get():
@@ -2469,6 +2636,8 @@ def api_settings_get():
     if not user:
         return jsonify({"success": False, "error": "User not found"}), 404
 
+    from tiers import get_all_limits
+
     # Never return decrypted email in logs — just expose username
     return jsonify({
         "success": True,
@@ -2477,6 +2646,7 @@ def api_settings_get():
             "display_name": user.get("username", ""),
             "is_pro": bool(user.get("is_pro")),
             "tier": user.get("tier", "free"),
+            "tier_limits": get_all_limits(user["user_id"]),
         },
         "preferences": user.get("preferences") or {},
     })
@@ -3976,6 +4146,22 @@ def api_watchlist_add_symbol(watchlist_id):
     symbol = (data.get("symbol") or "").strip().upper()
     if not symbol:
         return jsonify({"error": "symbol is required"}), 400
+
+    import math as _math
+    from database import get_database_manager
+    from tiers import get_limit
+
+    uid = session["user_id"]
+    db = get_database_manager()
+    limit = get_limit(uid, "watchlist_items")
+    if limit != _math.inf and db.count_user_watchlist_items(uid) >= int(limit):
+        return jsonify({
+            "error": "quota_exceeded",
+            "resource": "watchlist_items",
+            "limit": int(limit),
+            "message": f"Your plan allows {int(limit)} watchlist items. Upgrade to add more.",
+        }), 402
+
     try:
         watchlist_svc.add_symbol(watchlist_id, symbol, None)
         return jsonify({"success": True, "symbol": symbol})

--- a/src/billing/whop_service.py
+++ b/src/billing/whop_service.py
@@ -1,0 +1,92 @@
+"""Whop webhook signature verification + lightweight HTTP client.
+
+Whop signs webhooks with HMAC-SHA256 over `webhook_id.timestamp.body`,
+keyed by a base64-encoded secret. We don't need the full SDK — just verify
+sigs and call /users/{id}/access/{resource_id} for fallback re-checks.
+"""
+
+import base64
+import hashlib
+import hmac
+import json
+import os
+import time
+from typing import Any, Dict
+
+import httpx
+
+
+WHOP_API_BASE = "https://api.whop.com/v5"
+SIG_TOLERANCE_SEC = 5 * 60  # reject webhooks older than 5 min (replay protection)
+
+
+class WhopSignatureError(Exception):
+    """Raised when a webhook signature is missing, malformed, or invalid."""
+
+
+def _secret_bytes() -> bytes:
+    raw = os.getenv("WHOP_WEBHOOK_SECRET", "")
+    if not raw:
+        raise WhopSignatureError("WHOP_WEBHOOK_SECRET not set")
+    try:
+        return base64.b64decode(raw)
+    except Exception as e:
+        raise WhopSignatureError(f"WHOP_WEBHOOK_SECRET not valid base64: {e}")
+
+
+def verify_webhook(body: bytes, headers: Dict[str, str]) -> Dict[str, Any]:
+    """Verify the HMAC sig + freshness; return the parsed JSON event.
+
+    Whop headers (case-insensitive):
+      whop-signature   = "v1=<hex_hmac>"
+      whop-timestamp   = unix seconds
+      whop-webhook-id  = uuid
+    """
+    # Normalize header lookup
+    h = {k.lower(): v for k, v in headers.items()}
+    sig_header = h.get("whop-signature", "")
+    timestamp = h.get("whop-timestamp", "")
+    webhook_id = h.get("whop-webhook-id", "")
+
+    if not sig_header or not timestamp or not webhook_id:
+        raise WhopSignatureError("Missing Whop signature headers")
+
+    # Format: "v1=<hex>"
+    parts = dict(p.split("=", 1) for p in sig_header.split(",") if "=" in p)
+    provided = parts.get("v1")
+    if not provided:
+        raise WhopSignatureError("Bad signature header format")
+
+    # Replay protection
+    try:
+        ts = int(timestamp)
+    except ValueError:
+        raise WhopSignatureError("Bad timestamp")
+    if abs(time.time() - ts) > SIG_TOLERANCE_SEC:
+        raise WhopSignatureError("Timestamp outside tolerance window")
+
+    # Compute expected sig over "webhook_id.timestamp.body"
+    body_str = body.decode("utf-8") if isinstance(body, (bytes, bytearray)) else body
+    signed_payload = f"{webhook_id}.{timestamp}.{body_str}".encode("utf-8")
+    expected = hmac.new(_secret_bytes(), signed_payload, hashlib.sha256).hexdigest()
+
+    if not hmac.compare_digest(expected, provided):
+        raise WhopSignatureError("Signature mismatch")
+
+    try:
+        return json.loads(body_str)
+    except json.JSONDecodeError as e:
+        raise WhopSignatureError(f"Body not valid JSON: {e}")
+
+
+def check_access(whop_user_id: str, resource_id: str) -> Dict[str, Any]:
+    """Authoritative re-check via Whop API (used as a fallback if a webhook
+    is missed). Returns the raw response dict; caller decides what to do."""
+    api_key = os.getenv("WHOP_API_KEY")
+    if not api_key:
+        raise RuntimeError("WHOP_API_KEY not set")
+    url = f"{WHOP_API_BASE}/users/{whop_user_id}/access/{resource_id}"
+    with httpx.Client(timeout=10.0) as client:
+        resp = client.get(url, headers={"Authorization": f"Bearer {api_key}"})
+        resp.raise_for_status()
+        return resp.json()

--- a/src/database.py
+++ b/src/database.py
@@ -567,6 +567,36 @@ class DatabaseManager:
                     "WITH CHECK (user_id = auth.jwt()->>'sub')"
                 )
 
+                # Subscriptions: Whop is source of truth; we cache the active
+                # membership state here for fast tier/quota lookups.
+                cur.execute("""
+                    CREATE TABLE IF NOT EXISTS subscriptions (
+                        id                  VARCHAR(36) PRIMARY KEY,
+                        user_id             VARCHAR(36) NOT NULL REFERENCES users(user_id) ON DELETE CASCADE,
+                        whop_membership_id  VARCHAR(64) NOT NULL UNIQUE,
+                        whop_plan_id        VARCHAR(64) NOT NULL,
+                        tier                VARCHAR(20) NOT NULL,
+                        cadence             VARCHAR(20) NOT NULL,
+                        status              VARCHAR(20) NOT NULL DEFAULT 'active',
+                        current_period_end  TIMESTAMPTZ,
+                        created_at          TIMESTAMPTZ DEFAULT NOW(),
+                        updated_at          TIMESTAMPTZ DEFAULT NOW()
+                    )
+                """)
+                cur.execute(
+                    "CREATE INDEX IF NOT EXISTS idx_subscriptions_user_id ON subscriptions (user_id)"
+                )
+                cur.execute(
+                    "CREATE INDEX IF NOT EXISTS idx_subscriptions_status  ON subscriptions (status)"
+                )
+                cur.execute("ALTER TABLE subscriptions ENABLE ROW LEVEL SECURITY")
+                cur.execute("DROP POLICY IF EXISTS subscriptions_owner ON subscriptions")
+                cur.execute(
+                    "CREATE POLICY subscriptions_owner ON subscriptions "
+                    "FOR ALL USING (user_id = auth.jwt()->>'sub') "
+                    "WITH CHECK (user_id = auth.jwt()->>'sub')"
+                )
+
             conn.commit()
             logger.info("Database schema initialized")
 
@@ -1250,19 +1280,223 @@ class DatabaseManager:
             self._release(conn)
 
     def user_is_pro(self, user_id: str) -> bool:
-        """Paid / pro users bypass free-tier report quota (stub until billing)."""
+        """Paid users bypass free-tier quotas. True for tier in {starter, ultra}
+        OR legacy is_pro flag = true."""
         conn = None
         try:
             conn = self.get_connection()
             with conn.cursor() as cur:
                 cur.execute(
-                    "SELECT COALESCE(is_pro, FALSE) FROM users WHERE user_id = %s",
+                    "SELECT tier, COALESCE(is_pro, FALSE) FROM users WHERE user_id = %s",
                     (user_id,),
                 )
                 row = cur.fetchone()
-                return bool(row and row[0])
+                if not row:
+                    return False
+                tier = (row[0] or "free").lower()
+                return tier in ("starter", "ultra") or bool(row[1])
         except psycopg2.Error as e:
             raise RuntimeError(f"Failed to read user tier: {e}")
+        finally:
+            self._release(conn)
+
+    def set_user_tier(self, user_id: str, tier: str) -> None:
+        """Set users.tier and sync legacy is_pro flag."""
+        tier = (tier or "free").lower()
+        if tier not in ("free", "starter", "ultra"):
+            raise ValueError(f"unknown tier: {tier}")
+        is_pro = tier in ("starter", "ultra")
+        conn = None
+        try:
+            conn = self.get_connection()
+            with conn.cursor() as cur:
+                cur.execute(
+                    "UPDATE users SET tier = %s, is_pro = %s WHERE user_id = %s",
+                    (tier, is_pro, user_id),
+                )
+            conn.commit()
+        except psycopg2.Error as e:
+            if conn:
+                conn.rollback()
+            raise RuntimeError(f"Failed to set tier: {e}")
+        finally:
+            self._release(conn)
+
+    def upsert_subscription(
+        self,
+        *,
+        user_id: str,
+        whop_membership_id: str,
+        whop_plan_id: str,
+        tier: str,
+        cadence: str,
+        status: str = "active",
+        current_period_end=None,
+    ) -> str:
+        """Insert or update a subscription row keyed by whop_membership_id."""
+        import uuid as _uuid
+
+        sub_id = str(_uuid.uuid4())
+        conn = None
+        try:
+            conn = self.get_connection()
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    INSERT INTO subscriptions
+                        (id, user_id, whop_membership_id, whop_plan_id, tier,
+                         cadence, status, current_period_end, updated_at)
+                    VALUES (%s, %s, %s, %s, %s, %s, %s, %s, NOW())
+                    ON CONFLICT (whop_membership_id) DO UPDATE SET
+                        whop_plan_id       = EXCLUDED.whop_plan_id,
+                        tier               = EXCLUDED.tier,
+                        cadence            = EXCLUDED.cadence,
+                        status             = EXCLUDED.status,
+                        current_period_end = EXCLUDED.current_period_end,
+                        updated_at         = NOW()
+                    RETURNING id
+                    """,
+                    (sub_id, user_id, whop_membership_id, whop_plan_id, tier,
+                     cadence, status, current_period_end),
+                )
+                row = cur.fetchone()
+            conn.commit()
+            return row[0] if row else sub_id
+        except psycopg2.Error as e:
+            if conn:
+                conn.rollback()
+            raise RuntimeError(f"Failed to upsert subscription: {e}")
+        finally:
+            self._release(conn)
+
+    def get_active_subscription(self, user_id: str):
+        """Return the most recent active subscription row, or None."""
+        conn = None
+        try:
+            conn = self.get_connection()
+            with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+                cur.execute(
+                    """
+                    SELECT id, user_id, whop_membership_id, whop_plan_id,
+                           tier, cadence, status, current_period_end,
+                           created_at, updated_at
+                    FROM subscriptions
+                    WHERE user_id = %s AND status = 'active'
+                    ORDER BY updated_at DESC
+                    LIMIT 1
+                    """,
+                    (user_id,),
+                )
+                return cur.fetchone()
+        except psycopg2.Error as e:
+            raise RuntimeError(f"Failed to read subscription: {e}")
+        finally:
+            self._release(conn)
+
+    def set_subscription_status(self, whop_membership_id: str, status: str) -> None:
+        conn = None
+        try:
+            conn = self.get_connection()
+            with conn.cursor() as cur:
+                cur.execute(
+                    "UPDATE subscriptions SET status = %s, updated_at = NOW() "
+                    "WHERE whop_membership_id = %s",
+                    (status, whop_membership_id),
+                )
+            conn.commit()
+        except psycopg2.Error as e:
+            if conn:
+                conn.rollback()
+            raise RuntimeError(f"Failed to set subscription status: {e}")
+        finally:
+            self._release(conn)
+
+    def get_subscription_user(self, whop_membership_id: str):
+        """Look up the user_id behind an existing subscription row."""
+        conn = None
+        try:
+            conn = self.get_connection()
+            with conn.cursor() as cur:
+                cur.execute(
+                    "SELECT user_id FROM subscriptions WHERE whop_membership_id = %s",
+                    (whop_membership_id,),
+                )
+                row = cur.fetchone()
+                return row[0] if row else None
+        except psycopg2.Error as e:
+            raise RuntimeError(f"Failed to read subscription user: {e}")
+        finally:
+            self._release(conn)
+
+    def update_subscription_period_end(self, whop_membership_id: str, period_end) -> None:
+        conn = None
+        try:
+            conn = self.get_connection()
+            with conn.cursor() as cur:
+                cur.execute(
+                    "UPDATE subscriptions SET current_period_end = %s, updated_at = NOW() "
+                    "WHERE whop_membership_id = %s",
+                    (period_end, whop_membership_id),
+                )
+            conn.commit()
+        except psycopg2.Error as e:
+            if conn:
+                conn.rollback()
+            raise RuntimeError(f"Failed to update period end: {e}")
+        finally:
+            self._release(conn)
+
+    def count_user_portfolios(self, user_id: str) -> int:
+        conn = None
+        try:
+            conn = self.get_connection()
+            with conn.cursor() as cur:
+                cur.execute(
+                    "SELECT COUNT(*) FROM portfolios WHERE user_id = %s",
+                    (user_id,),
+                )
+                row = cur.fetchone()
+                return int(row[0]) if row else 0
+        except psycopg2.Error as e:
+            raise RuntimeError(f"Failed to count portfolios: {e}")
+        finally:
+            self._release(conn)
+
+    def count_user_watchlist_items(self, user_id: str) -> int:
+        conn = None
+        try:
+            conn = self.get_connection()
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    SELECT COUNT(wi.*)
+                    FROM watchlist_items wi
+                    JOIN watchlists w ON w.watchlist_id = wi.watchlist_id
+                    WHERE w.user_id = %s
+                    """,
+                    (user_id,),
+                )
+                row = cur.fetchone()
+                return int(row[0]) if row else 0
+        except psycopg2.Error as e:
+            raise RuntimeError(f"Failed to count watchlist items: {e}")
+        finally:
+            self._release(conn)
+
+    def count_user_active_alerts(self, user_id: str) -> int:
+        conn = None
+        try:
+            conn = self.get_connection()
+            with conn.cursor() as cur:
+                cur.execute(
+                    "SELECT COUNT(*) FROM price_alerts "
+                    "WHERE user_id = %s AND COALESCE(active, TRUE) = TRUE",
+                    (user_id,),
+                )
+                row = cur.fetchone()
+                return int(row[0]) if row else 0
+        except psycopg2.Error as e:
+            raise RuntimeError(f"Failed to count alerts: {e}")
         finally:
             self._release(conn)
 

--- a/src/report_usage.py
+++ b/src/report_usage.py
@@ -1,5 +1,6 @@
-"""Free-tier monthly research report quota (per user, per calendar month)."""
+"""Per-user monthly research report quota (tier-aware)."""
 
+import math
 import os
 from datetime import datetime, timezone
 from typing import Optional, Tuple, Any
@@ -29,14 +30,20 @@ def quota_exceeded_for_user(
     """
     Returns (exceeded, limit, used).
 
-    If limit is 0, never exceeded (free enforcement off).
-    Pro users never exceeded.
+    Limit comes from the user's tier (tiers.TIER_LIMITS). Ultra = unlimited.
+    A free-tier global override of 0 disables enforcement entirely.
     """
-    limit = get_free_tier_report_limit()
-    if limit == 0:
+    # Hard global off-switch (env)
+    if get_free_tier_report_limit() == 0:
         return False, 0, 0
-    if db.user_is_pro(user_id):
-        return False, limit, 0
+
+    from tiers import get_limit
+
+    limit_f = get_limit(user_id, "reports_per_month")
+    if limit_f == math.inf:
+        return False, -1, 0
+
+    limit = int(limit_f)
     p = period or current_period_month()
     used = db.get_report_usage_count(user_id, p)
     return used >= limit, limit, used

--- a/src/tiers.py
+++ b/src/tiers.py
@@ -1,0 +1,143 @@
+"""Single source of truth for paid tier limits + Whop checkout URLs.
+
+Tiers: free, starter, ultra. Each product in Whop has ONE checkout URL — the
+customer picks monthly/yearly on Whop's page. Tier rides in metadata; cadence
+is read from the membership webhook payload.
+"""
+
+import math
+import os
+from typing import Dict, Optional
+
+
+TIER_LIMITS: Dict[str, Dict[str, float]] = {
+    "free": {
+        "reports_per_month": 3,
+        "portfolios": 1,
+        "watchlist_items": 10,
+        "price_alerts": 5,
+    },
+    "starter": {
+        "reports_per_month": 10,
+        "portfolios": 3,
+        "watchlist_items": 20,
+        "price_alerts": 15,
+    },
+    "ultra": {
+        "reports_per_month": math.inf,
+        "portfolios": math.inf,
+        "watchlist_items": math.inf,
+        "price_alerts": math.inf,
+    },
+}
+
+
+def _product_urls() -> Dict[str, Optional[str]]:
+    """Re-read each call so monkeypatch works in tests."""
+    return {
+        "starter": os.getenv("WHOP_STARTER_URL"),
+        "ultra": os.getenv("WHOP_ULTRA_URL"),
+    }
+
+
+def get_user_tier(user_id: str) -> str:
+    """Read users.tier; default to 'free' on any miss."""
+    from database import get_database_manager
+
+    db = get_database_manager()
+    user = db.get_user_by_id(user_id)
+    if not user:
+        return "free"
+    tier = (user.get("tier") or "free").lower()
+    if tier not in TIER_LIMITS:
+        return "free"
+    return tier
+
+
+def get_limit(user_id: str, key: str) -> float:
+    """Return the numeric cap for `key` for the user's current tier."""
+    tier = get_user_tier(user_id)
+    return TIER_LIMITS[tier].get(key, 0)
+
+
+def get_all_limits(user_id: str) -> Dict[str, float]:
+    """Full caps dict for the user's tier (for API responses).
+    JSON cannot encode inf, so unlimited becomes -1."""
+    tier = get_user_tier(user_id)
+    out = {}
+    for k, v in TIER_LIMITS[tier].items():
+        out[k] = -1 if v == math.inf else int(v)
+    return out
+
+
+def plans_public() -> Dict[str, Dict[str, Optional[str]]]:
+    """Product URLs + display prices for the SPA pricing page.
+
+    Both monthly + yearly point to the same product URL; the customer
+    picks the cadence on Whop's page.
+    """
+    urls = _product_urls()
+    return {
+        "starter": {
+            "url": urls["starter"],
+            "price_monthly": 19,
+            "price_yearly": 190,
+        },
+        "ultra": {
+            "url": urls["ultra"],
+            "price_monthly": 59,
+            "price_yearly": 590,
+        },
+    }
+
+
+def build_checkout_url(tier: str, user_id: str) -> Optional[str]:
+    """Append metadata params Whop will store on the resulting membership.
+
+    Returns None if the product URL isn't configured in env.
+    """
+    from urllib.parse import urlencode, urlsplit, urlunsplit, parse_qsl
+
+    tier = (tier or "").lower()
+    if tier not in ("starter", "ultra"):
+        return None
+    base = _product_urls().get(tier)
+    if not base:
+        return None
+
+    parts = urlsplit(base)
+    existing = dict(parse_qsl(parts.query))
+    existing.update({
+        "metadata[user_id]": user_id,
+        "metadata[tier]": tier,
+    })
+    return urlunsplit((parts.scheme, parts.netloc, parts.path, urlencode(existing), parts.fragment))
+
+
+def derive_cadence_from_webhook(payload: dict) -> str:
+    """Whop puts the renewal interval somewhere on the membership/plan payload.
+
+    We try a handful of common field names. Returns 'monthly' or 'yearly'.
+    Defaults to 'monthly' if we can't figure it out — better than blocking
+    activation over a missing field.
+    """
+    candidates = []
+    for source in (payload, payload.get("plan") or {}, payload.get("membership") or {}):
+        if not isinstance(source, dict):
+            continue
+        for key in (
+            "renewal_period",
+            "billing_period",
+            "interval",
+            "renewal_period_initial_interval",
+            "renewal_period_initial_unit",
+            "plan_type",
+        ):
+            v = source.get(key)
+            if v:
+                candidates.append(str(v).lower())
+
+    blob = " ".join(candidates)
+    if "year" in blob or "annual" in blob or "annually" in blob:
+        return "yearly"
+    return "monthly"

--- a/stockpro-web/src/App.tsx
+++ b/stockpro-web/src/App.tsx
@@ -30,6 +30,7 @@ const Alerts = lazy(() => import('./pages/Alerts'))
 const TickerPage = lazy(() => import('./pages/TickerPage'))
 const Settings = lazy(() => import('./pages/Settings'))
 const DevicePage = lazy(() => import('./pages/DevicePage'))
+const Pricing = lazy(() => import('./pages/Pricing'))
 
 /**
  * Runs at app level (never unmounts on navigation) so toast dedup works.
@@ -320,6 +321,15 @@ export default function App() {
               />
             </SignedOut>
           </>
+        }
+      />
+
+      <Route
+        path="/pricing"
+        element={
+          <SignedIn>
+            <Pricing />
+          </SignedIn>
         }
       />
 

--- a/stockpro-web/src/components/UpgradeNudge.tsx
+++ b/stockpro-web/src/components/UpgradeNudge.tsx
@@ -1,0 +1,72 @@
+import { Link } from 'react-router'
+
+type Props = {
+  resource?: string
+  message?: string
+  onDismiss?: () => void
+}
+
+/** Small banner shown when an API call returns 402 quota_exceeded. */
+export default function UpgradeNudge({ resource, message, onDismiss }: Props) {
+  const text =
+    message ||
+    (resource
+      ? `You hit your ${resource.replace(/_/g, ' ')} limit. Upgrade for more.`
+      : 'You hit your plan limit. Upgrade to keep going.')
+
+  return (
+    <div
+      role="alert"
+      style={{
+        background: 'linear-gradient(135deg, rgba(214,211,209,0.08), rgba(214,211,209,0.03))',
+        border: '1px solid #292524',
+        borderRadius: 12,
+        padding: '12px 16px',
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        gap: 16,
+        color: '#fafaf9',
+        fontSize: 13.5,
+      }}
+    >
+      <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+        <span className="material-symbols-outlined" style={{ fontSize: 20, color: '#d6d3d1' }}>workspace_premium</span>
+        <span>{text}</span>
+      </div>
+      <div style={{ display: 'flex', gap: 8 }}>
+        <Link
+          to="/pricing"
+          style={{
+            padding: '6px 14px',
+            borderRadius: 100,
+            background: '#d6d3d1',
+            color: '#0c0a09',
+            fontSize: 12.5,
+            fontWeight: 600,
+            textDecoration: 'none',
+            whiteSpace: 'nowrap',
+          }}
+        >
+          See plans
+        </Link>
+        {onDismiss && (
+          <button
+            onClick={onDismiss}
+            style={{
+              padding: '6px 10px',
+              borderRadius: 100,
+              background: 'transparent',
+              color: '#a8a29e',
+              border: '1px solid #292524',
+              cursor: 'pointer',
+              fontSize: 12.5,
+            }}
+          >
+            Dismiss
+          </button>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/stockpro-web/src/pages/Pricing.tsx
+++ b/stockpro-web/src/pages/Pricing.tsx
@@ -1,0 +1,213 @@
+import { useState } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import toast from 'react-hot-toast'
+import AppNav from '../components/AppNav'
+import { useApiClient } from '../api/client'
+
+type Cadence = 'monthly' | 'yearly'
+
+type PlanInfo = {
+  url: string | null
+  price_monthly: number
+  price_yearly: number
+}
+
+type PlansResp = {
+  success: boolean
+  plans: { starter: PlanInfo; ultra: PlanInfo }
+}
+
+const FEATURES = {
+  free: ['3 research reports / mo', '1 portfolio', 'Watchlist & alerts (basic)'],
+  starter: ['10 research reports / mo', '3 portfolios', '20 watchlist tickers', '15 price alerts'],
+  ultra: ['Unlimited reports', 'Unlimited portfolios', 'Unlimited watchlist', 'Unlimited alerts'],
+}
+
+export default function Pricing() {
+  const api = useApiClient()
+  const [cadence, setCadence] = useState<Cadence>('monthly')
+
+  const { data } = useQuery<PlansResp>({
+    queryKey: ['billing-plans'],
+    queryFn: async () => {
+      const res = await api.get('/api/billing/plans')
+      if (!res.ok) throw new Error('Failed')
+      return res.json()
+    },
+  })
+
+  const { data: settings } = useQuery({
+    queryKey: ['settings'],
+    queryFn: async () => {
+      const res = await api.get('/api/settings')
+      if (!res.ok) throw new Error('Failed')
+      return res.json()
+    },
+  })
+
+  const currentTier = settings?.profile?.tier || 'free'
+
+  const startCheckout = async (tier: 'starter' | 'ultra') => {
+    const res = await api.post('/api/billing/checkout-session', { tier })
+    if (!res.ok) {
+      toast.error('Could not start checkout. Plan may not be configured yet.')
+      return
+    }
+    const body = await res.json()
+    if (!body?.checkout_url) {
+      toast.error('Plan not configured.')
+      return
+    }
+    // Open Whop hosted checkout in a new tab — payment + webhook handles the rest.
+    window.open(body.checkout_url, '_blank', 'noopener,noreferrer')
+    toast.success('Opening checkout… Your plan will activate once payment completes.')
+  }
+
+  return (
+    <div style={{ background: '#0c0a09', minHeight: '100vh', color: '#fafaf9' }}>
+      <AppNav />
+      <main style={{ maxWidth: 1100, margin: '0 auto', padding: '48px 24px 96px' }}>
+        <header style={{ textAlign: 'center', marginBottom: 32 }}>
+          <h1 style={{ fontFamily: 'Nunito, "Secular One", Heebo, sans-serif', fontSize: 38, fontWeight: 700, letterSpacing: '-0.02em' }}>
+            Plans &amp; pricing
+          </h1>
+          <p style={{ fontSize: 15, color: '#a8a29e', marginTop: 8 }}>
+            Pick a plan that matches how much you research.
+          </p>
+        </header>
+
+        <div style={{ display: 'flex', justifyContent: 'center', marginBottom: 28 }}>
+          <div style={{ display: 'inline-flex', background: '#1c1917', border: '1px solid #292524', borderRadius: 100, padding: 4 }}>
+            {(['monthly', 'yearly'] as Cadence[]).map(c => (
+              <button
+                key={c}
+                onClick={() => setCadence(c)}
+                style={{
+                  padding: '8px 18px',
+                  borderRadius: 100,
+                  border: 'none',
+                  cursor: 'pointer',
+                  fontSize: 13.5,
+                  fontWeight: 500,
+                  background: cadence === c ? '#d6d3d1' : 'transparent',
+                  color: cadence === c ? '#0c0a09' : '#a8a29e',
+                }}
+              >
+                {c === 'monthly' ? 'Monthly' : 'Yearly (2 months free)'}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(260px, 1fr))', gap: 16 }}>
+          <PlanCard
+            name="Free"
+            price={0}
+            cadence={cadence}
+            features={FEATURES.free}
+            current={currentTier === 'free'}
+          />
+          <PlanCard
+            name="Starter"
+            price={cadence === 'monthly' ? data?.plans.starter.price_monthly ?? 19 : data?.plans.starter.price_yearly ?? 190}
+            cadence={cadence}
+            features={FEATURES.starter}
+            current={currentTier === 'starter'}
+            cta={currentTier === 'starter' ? 'Current plan' : 'Upgrade'}
+            disabled={currentTier === 'starter'}
+            onClick={() => startCheckout('starter')}
+          />
+          <PlanCard
+            name="Ultra"
+            price={cadence === 'monthly' ? data?.plans.ultra.price_monthly ?? 59 : data?.plans.ultra.price_yearly ?? 590}
+            cadence={cadence}
+            features={FEATURES.ultra}
+            current={currentTier === 'ultra'}
+            cta={currentTier === 'ultra' ? 'Current plan' : 'Upgrade'}
+            disabled={currentTier === 'ultra'}
+            highlight
+            onClick={() => startCheckout('ultra')}
+          />
+        </div>
+
+        <p style={{ textAlign: 'center', color: '#a8a29e', fontSize: 12.5, marginTop: 24 }}>
+          Checkout opens in a new tab where you can pick monthly or yearly. Your plan activates within seconds of payment.
+        </p>
+      </main>
+    </div>
+  )
+}
+
+function PlanCard({
+  name,
+  price,
+  cadence,
+  features,
+  current,
+  cta,
+  disabled,
+  highlight,
+  onClick,
+}: {
+  name: string
+  price: number
+  cadence: Cadence
+  features: string[]
+  current?: boolean
+  cta?: string
+  disabled?: boolean
+  highlight?: boolean
+  onClick?: () => void
+}) {
+  return (
+    <div style={{
+      background: highlight ? 'linear-gradient(180deg, #1c1917, #0c0a09)' : '#1c1917',
+      border: `1px solid ${highlight ? '#d6d3d1' : '#292524'}`,
+      borderRadius: 18,
+      padding: 24,
+      display: 'flex',
+      flexDirection: 'column',
+      gap: 16,
+      position: 'relative',
+    }}>
+      {highlight && (
+        <span style={{ position: 'absolute', top: 12, insetInlineEnd: 12, fontSize: 11, fontWeight: 600, padding: '3px 10px', borderRadius: 100, background: '#d6d3d1', color: '#0c0a09' }}>
+          POPULAR
+        </span>
+      )}
+      <div>
+        <div style={{ fontFamily: 'Nunito, "Secular One", Heebo, sans-serif', fontSize: 20, fontWeight: 700 }}>{name}</div>
+        <div style={{ marginTop: 8 }}>
+          <span style={{ fontSize: 36, fontWeight: 700, color: '#fafaf9' }}>${price}</span>
+          {price > 0 && <span style={{ fontSize: 13, color: '#a8a29e', marginInlineStart: 6 }}>/{cadence === 'monthly' ? 'mo' : 'yr'}</span>}
+        </div>
+      </div>
+      <ul style={{ listStyle: 'none', padding: 0, margin: 0, display: 'flex', flexDirection: 'column', gap: 8 }}>
+        {features.map((f, i) => (
+          <li key={i} style={{ display: 'flex', alignItems: 'center', gap: 8, fontSize: 13.5, color: '#d6d3d1' }}>
+            <span className="material-symbols-outlined" style={{ fontSize: 16, color: '#22c55e' }}>check</span>
+            {f}
+          </li>
+        ))}
+      </ul>
+      <button
+        disabled={disabled || !onClick}
+        onClick={onClick}
+        style={{
+          marginTop: 'auto',
+          padding: '10px 16px',
+          borderRadius: 100,
+          border: 'none',
+          background: current ? '#292524' : highlight ? '#d6d3d1' : '#1c1917',
+          color: current ? '#a8a29e' : highlight ? '#0c0a09' : '#fafaf9',
+          fontSize: 13.5,
+          fontWeight: 600,
+          cursor: disabled || !onClick ? 'default' : 'pointer',
+          outline: !highlight && !current ? '1px solid #292524' : 'none',
+        }}
+      >
+        {cta || (current ? 'Current plan' : 'Get started')}
+      </button>
+    </div>
+  )
+}

--- a/stockpro-web/src/pages/Settings.tsx
+++ b/stockpro-web/src/pages/Settings.tsx
@@ -304,6 +304,14 @@ export default function Settings() {
             </div>
           )}
 
+          {/* PLAN / BILLING */}
+          {activeSection === 'plan' && (
+            <PlanSection
+              tier={settingsData?.profile?.tier || 'free'}
+              limits={settingsData?.profile?.tier_limits || {}}
+            />
+          )}
+
           {/* CLI TOKENS */}
           {activeSection === 'cli' && <CliTokensSection />}
 
@@ -459,6 +467,65 @@ function CliTokensSection() {
           ))
         )}
       </div>
+    </div>
+  )
+}
+
+
+// ==================== Plan / Billing Section ====================
+
+function PlanSection({ tier, limits }: { tier: string; limits: Record<string, number> }) {
+  const tierLabel = tier === 'free' ? 'Free' : tier === 'starter' ? 'Starter' : tier === 'ultra' ? 'Ultra' : tier
+  const fmt = (n: number | undefined) => (n === -1 || n === undefined ? 'Unlimited' : String(n))
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+      <div style={{ background: '#1c1917', border: '1px solid #292524', borderRadius: 14, padding: 20 }}>
+        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', marginBottom: 16 }}>
+          <div>
+            <div style={{ fontSize: 12, color: '#a8a29e', textTransform: 'uppercase', letterSpacing: 0.6 }}>Current plan</div>
+            <div style={{ fontSize: 22, fontWeight: 600, color: '#fafaf9', marginTop: 4 }}>{tierLabel}</div>
+          </div>
+          <a
+            href="/pricing"
+            style={{ padding: '9px 16px', borderRadius: 100, background: '#d6d3d1', color: '#0c0a09', fontSize: 13, fontWeight: 600, textDecoration: 'none' }}
+          >
+            {tier === 'free' ? 'Upgrade' : 'Change plan'}
+          </a>
+        </div>
+        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(2, 1fr)', gap: 12 }}>
+          <Quota label="Reports / month" value={fmt(limits.reports_per_month)} />
+          <Quota label="Portfolios" value={fmt(limits.portfolios)} />
+          <Quota label="Watchlist items" value={fmt(limits.watchlist_items)} />
+          <Quota label="Price alerts" value={fmt(limits.price_alerts)} />
+        </div>
+      </div>
+
+      {tier !== 'free' && (
+        <div style={{ background: '#1c1917', border: '1px solid #292524', borderRadius: 14, padding: 20, display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 16 }}>
+          <div>
+            <div style={{ fontSize: 14, fontWeight: 500, color: '#fafaf9', marginBottom: 4 }}>Manage subscription</div>
+            <div style={{ fontSize: 12.5, color: '#a8a29e' }}>Update payment, change plan, or cancel via the Whop member portal.</div>
+          </div>
+          <a
+            href="https://whop.com/orders/"
+            target="_blank"
+            rel="noopener noreferrer"
+            style={{ padding: '8px 14px', borderRadius: 8, border: '1px solid #292524', background: '#0c0a09', color: '#fafaf9', fontSize: 12.5, fontWeight: 500, textDecoration: 'none', whiteSpace: 'nowrap' }}
+          >
+            Open Whop portal
+          </a>
+        </div>
+      )}
+    </div>
+  )
+}
+
+function Quota({ label, value }: { label: string; value: string }) {
+  return (
+    <div style={{ background: '#0c0a09', border: '1px solid #292524', borderRadius: 10, padding: 14 }}>
+      <div style={{ fontSize: 11.5, color: '#a8a29e', textTransform: 'uppercase', letterSpacing: 0.5 }}>{label}</div>
+      <div style={{ fontSize: 18, fontWeight: 600, color: '#fafaf9', marginTop: 6 }}>{value}</div>
     </div>
   )
 }

--- a/tests/test_flask_price_alerts.py
+++ b/tests/test_flask_price_alerts.py
@@ -49,6 +49,8 @@ def test_create_alert_success(client, logged_in):
         uid = sess["user_id"]
     with patch("database.get_database_manager") as mock_db:
         db = MagicMock()
+        db.get_user_by_id.return_value = {"tier": "starter"}
+        db.count_user_active_alerts.return_value = 0
         mock_db.return_value = db
         r = client.post(
             "/api/alerts",

--- a/tests/test_quota_enforcement.py
+++ b/tests/test_quota_enforcement.py
@@ -1,0 +1,112 @@
+"""Quota gates: portfolio create, watchlist add, alert create -> 402 at limit."""
+
+import uuid
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app import app
+
+
+@pytest.fixture
+def client():
+    app.config["TESTING"] = True
+    app.config["WTF_CSRF_ENABLED"] = False
+    with app.test_client() as c:
+        yield c
+
+
+@pytest.fixture
+def logged_in(client):
+    with client.session_transaction() as sess:
+        sess["user_id"] = "u_test"
+        sess["email"] = "q@test.com"
+        sess["name"] = "Q User"
+
+
+# ---- Portfolios: free tier cap = 1 ----
+
+def test_portfolio_create_blocked_at_free_limit(client, logged_in):
+    db = MagicMock()
+    db.get_user_by_id.return_value = {"tier": "free"}
+    db.count_user_portfolios.return_value = 1  # already at limit
+    with patch("database.get_database_manager", return_value=db):
+        r = client.post("/api/portfolios", json={"name": "Second"})
+    assert r.status_code == 402
+    body = r.get_json()
+    assert body["error"] == "quota_exceeded"
+    assert body["resource"] == "portfolios"
+
+
+def test_portfolio_create_allowed_below_limit(client, logged_in):
+    db = MagicMock()
+    db.get_user_by_id.return_value = {"tier": "free"}
+    db.count_user_portfolios.return_value = 0
+    with patch("database.get_database_manager", return_value=db), \
+         patch("app.get_portfolio_service") as mock_svc:
+        svc = MagicMock()
+        svc.create_portfolio.return_value = "pf_1"
+        mock_svc.return_value = svc
+        r = client.post("/api/portfolios", json={"name": "First", "track_cash": False})
+    assert r.status_code == 200
+    assert r.get_json()["ok"] is True
+
+
+def test_portfolio_create_unlimited_for_ultra(client, logged_in):
+    db = MagicMock()
+    db.get_user_by_id.return_value = {"tier": "ultra"}
+    # count_user_portfolios should NOT be checked for ultra (unlimited)
+    with patch("database.get_database_manager", return_value=db), \
+         patch("app.get_portfolio_service") as mock_svc:
+        svc = MagicMock()
+        svc.create_portfolio.return_value = "pf_X"
+        mock_svc.return_value = svc
+        r = client.post("/api/portfolios", json={"name": "many", "track_cash": False})
+    assert r.status_code == 200
+
+
+# ---- Alerts: free tier cap = 5 ----
+
+def test_alert_create_blocked_at_free_limit(client, logged_in):
+    db = MagicMock()
+    db.get_user_by_id.return_value = {"tier": "free"}
+    db.count_user_active_alerts.return_value = 5
+    with patch("database.get_database_manager", return_value=db):
+        r = client.post(
+            "/api/alerts",
+            json={"symbol": "AAPL", "direction": "above", "target_price": 200},
+        )
+    assert r.status_code == 402
+    assert r.get_json()["resource"] == "price_alerts"
+
+
+def test_alert_create_allowed_for_starter_under_15(client, logged_in):
+    db = MagicMock()
+    db.get_user_by_id.return_value = {"tier": "starter"}
+    db.count_user_active_alerts.return_value = 14
+    with patch("database.get_database_manager", return_value=db):
+        r = client.post(
+            "/api/alerts",
+            json={"symbol": "AAPL", "direction": "above", "target_price": 200},
+        )
+    assert r.status_code == 200
+    db.create_price_alert.assert_called_once()
+
+
+# ---- Watchlist: free tier cap = 10 ----
+
+def test_watchlist_add_blocked_at_free_limit(client, logged_in):
+    db = MagicMock()
+    db.get_user_by_id.return_value = {"tier": "free"}
+    db.count_user_watchlist_items.return_value = 10
+
+    wl_svc = MagicMock()
+    wl_svc.db.get_watchlist.return_value = {"watchlist_id": "wl_1", "user_id": "u_test"}
+
+    with patch("database.get_database_manager", return_value=db), \
+         patch("app.get_watchlist_service", return_value=wl_svc):
+        r = client.post("/api/watchlist/wl_1/symbol", json={"symbol": "TSLA"})
+
+    assert r.status_code == 402
+    assert r.get_json()["resource"] == "watchlist_items"
+    wl_svc.add_symbol.assert_not_called()

--- a/tests/test_tiers.py
+++ b/tests/test_tiers.py
@@ -1,0 +1,103 @@
+"""Tier limit lookups + Whop checkout URL helpers."""
+
+import math
+from unittest.mock import MagicMock, patch
+from urllib.parse import parse_qs, urlsplit
+
+import tiers
+
+
+def test_tier_limits_shape():
+    for tier in ("free", "starter", "ultra"):
+        assert tier in tiers.TIER_LIMITS
+        for k in ("reports_per_month", "portfolios", "watchlist_items", "price_alerts"):
+            assert k in tiers.TIER_LIMITS[tier]
+
+
+def test_ultra_unlimited():
+    for v in tiers.TIER_LIMITS["ultra"].values():
+        assert v == math.inf
+
+
+def test_starter_caps():
+    s = tiers.TIER_LIMITS["starter"]
+    assert s["reports_per_month"] == 10
+    assert s["portfolios"] == 3
+    assert s["watchlist_items"] == 20
+    assert s["price_alerts"] == 15
+
+
+def test_get_user_tier_default_when_missing():
+    db = MagicMock()
+    db.get_user_by_id.return_value = None
+    with patch("database.get_database_manager", return_value=db):
+        assert tiers.get_user_tier("u_nope") == "free"
+
+
+def test_get_user_tier_normalizes_unknown_value():
+    db = MagicMock()
+    db.get_user_by_id.return_value = {"tier": "enterprise"}
+    with patch("database.get_database_manager", return_value=db):
+        assert tiers.get_user_tier("u1") == "free"
+
+
+def test_get_limit_starter():
+    db = MagicMock()
+    db.get_user_by_id.return_value = {"tier": "starter"}
+    with patch("database.get_database_manager", return_value=db):
+        assert tiers.get_limit("u1", "portfolios") == 3
+        assert tiers.get_limit("u1", "reports_per_month") == 10
+
+
+def test_get_all_limits_serializes_inf_as_minus_one():
+    db = MagicMock()
+    db.get_user_by_id.return_value = {"tier": "ultra"}
+    with patch("database.get_database_manager", return_value=db):
+        out = tiers.get_all_limits("u1")
+        for v in out.values():
+            assert v == -1
+
+
+def test_plans_public_reads_env(monkeypatch):
+    monkeypatch.setenv("WHOP_STARTER_URL", "https://whop.com/x/starter/")
+    monkeypatch.setenv("WHOP_ULTRA_URL", "https://whop.com/x/ultra/")
+    p = tiers.plans_public()
+    assert p["starter"]["url"] == "https://whop.com/x/starter/"
+    assert p["ultra"]["url"] == "https://whop.com/x/ultra/"
+    assert p["starter"]["price_monthly"] == 19
+    assert p["ultra"]["price_yearly"] == 590
+
+
+def test_build_checkout_url_appends_metadata(monkeypatch):
+    monkeypatch.setenv("WHOP_STARTER_URL", "https://whop.com/org/starter/")
+    url = tiers.build_checkout_url("starter", "user_abc")
+    assert url is not None
+    parts = urlsplit(url)
+    assert parts.netloc == "whop.com"
+    assert parts.path == "/org/starter/"
+    qs = parse_qs(parts.query)
+    assert qs["metadata[user_id]"] == ["user_abc"]
+    assert qs["metadata[tier]"] == ["starter"]
+
+
+def test_build_checkout_url_returns_none_when_unconfigured(monkeypatch):
+    monkeypatch.delenv("WHOP_ULTRA_URL", raising=False)
+    assert tiers.build_checkout_url("ultra", "user_x") is None
+
+
+def test_build_checkout_url_rejects_bad_tier(monkeypatch):
+    monkeypatch.setenv("WHOP_STARTER_URL", "https://whop.com/x/starter/")
+    assert tiers.build_checkout_url("free", "u") is None
+    assert tiers.build_checkout_url("bogus", "u") is None
+
+
+def test_derive_cadence_yearly_from_renewal_period():
+    assert tiers.derive_cadence_from_webhook({"renewal_period": "yearly"}) == "yearly"
+    assert tiers.derive_cadence_from_webhook({"plan": {"renewal_period": "annual"}}) == "yearly"
+    assert tiers.derive_cadence_from_webhook({"interval": "year"}) == "yearly"
+
+
+def test_derive_cadence_monthly_default():
+    assert tiers.derive_cadence_from_webhook({"renewal_period": "monthly"}) == "monthly"
+    # missing field → default monthly (don't block activation)
+    assert tiers.derive_cadence_from_webhook({}) == "monthly"

--- a/tests/test_whop_webhook.py
+++ b/tests/test_whop_webhook.py
@@ -1,0 +1,170 @@
+"""Whop webhook signature verification + event routing."""
+
+import base64
+import hashlib
+import hmac
+import json
+import time
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app import app
+from billing.whop_service import verify_webhook, WhopSignatureError
+
+
+SECRET_RAW = b"super-secret-bytes-here-32-chars-x"
+SECRET_B64 = base64.b64encode(SECRET_RAW).decode()
+
+
+@pytest.fixture(autouse=True)
+def env(monkeypatch):
+    monkeypatch.setenv("WHOP_WEBHOOK_SECRET", SECRET_B64)
+    monkeypatch.setenv("WHOP_STARTER_URL", "https://whop.com/x/starter/")
+    monkeypatch.setenv("WHOP_ULTRA_URL", "https://whop.com/x/ultra/")
+
+
+@pytest.fixture
+def client():
+    app.config["TESTING"] = True
+    app.config["WTF_CSRF_ENABLED"] = False
+    with app.test_client() as c:
+        yield c
+
+
+def _sign(body: bytes, webhook_id: str = "wh_1", ts: int | None = None) -> dict:
+    ts = ts or int(time.time())
+    payload = f"{webhook_id}.{ts}.{body.decode()}".encode()
+    sig = hmac.new(SECRET_RAW, payload, hashlib.sha256).hexdigest()
+    return {
+        "Whop-Signature": f"v1={sig}",
+        "Whop-Timestamp": str(ts),
+        "Whop-Webhook-Id": webhook_id,
+        "Content-Type": "application/json",
+    }
+
+
+# ----- verify_webhook unit tests -----
+
+def test_verify_webhook_accepts_valid_sig():
+    body = b'{"action":"membership.activated","data":{}}'
+    headers = _sign(body)
+    parsed = verify_webhook(body, headers)
+    assert parsed["action"] == "membership.activated"
+
+
+def test_verify_webhook_rejects_bad_sig():
+    body = b'{"hi":"there"}'
+    headers = _sign(body)
+    headers["Whop-Signature"] = "v1=deadbeef"
+    with pytest.raises(WhopSignatureError):
+        verify_webhook(body, headers)
+
+
+def test_verify_webhook_rejects_old_timestamp():
+    body = b'{"hi":"there"}'
+    headers = _sign(body, ts=int(time.time()) - 60 * 60)  # 1h old
+    with pytest.raises(WhopSignatureError):
+        verify_webhook(body, headers)
+
+
+def test_verify_webhook_rejects_missing_headers():
+    with pytest.raises(WhopSignatureError):
+        verify_webhook(b"{}", {})
+
+
+# ----- Flask route handler tests -----
+
+def _post(client, body_dict, **header_overrides):
+    body = json.dumps(body_dict).encode()
+    headers = _sign(body)
+    headers.update(header_overrides)
+    return client.post("/api/billing/webhook", data=body, headers=headers)
+
+
+def test_webhook_rejects_bad_signature(client):
+    r = client.post(
+        "/api/billing/webhook",
+        data=b"{}",
+        headers={"Whop-Signature": "v1=bad", "Whop-Timestamp": str(int(time.time())), "Whop-Webhook-Id": "x"},
+    )
+    assert r.status_code == 401
+
+
+def test_webhook_membership_activated_sets_tier(client):
+    payload = {
+        "action": "membership.activated",
+        "data": {
+            "id": "mem_123",
+            "plan_id": "plan_anything",
+            "metadata": {"user_id": "user_abc", "tier": "starter"},
+            "renewal_period": "monthly",
+            "expires_at": "2027-01-01T00:00:00Z",
+        },
+    }
+    db = MagicMock()
+    with patch("database.get_database_manager", return_value=db):
+        r = _post(client, payload)
+
+    assert r.status_code == 200
+    db.upsert_subscription.assert_called_once()
+    call_kwargs = db.upsert_subscription.call_args.kwargs
+    assert call_kwargs["user_id"] == "user_abc"
+    assert call_kwargs["whop_membership_id"] == "mem_123"
+    assert call_kwargs["tier"] == "starter"
+    assert call_kwargs["cadence"] == "monthly"
+    db.set_user_tier.assert_called_once_with("user_abc", "starter")
+
+
+def test_webhook_membership_yearly_ultra(client):
+    payload = {
+        "action": "membership.activated",
+        "data": {
+            "id": "mem_yr",
+            "metadata": {"user_id": "u9", "tier": "ultra"},
+            "renewal_period": "yearly",
+        },
+    }
+    db = MagicMock()
+    with patch("database.get_database_manager", return_value=db):
+        r = _post(client, payload)
+    assert r.status_code == 200
+    kw = db.upsert_subscription.call_args.kwargs
+    assert kw["tier"] == "ultra"
+    assert kw["cadence"] == "yearly"
+
+
+def test_webhook_membership_deactivated_downgrades(client):
+    payload = {
+        "action": "membership.deactivated",
+        "data": {"id": "mem_456", "metadata": {"user_id": "u_x"}},
+    }
+    db = MagicMock()
+    db.get_subscription_user.return_value = "u_x"
+    with patch("database.get_database_manager", return_value=db):
+        r = _post(client, payload)
+    assert r.status_code == 200
+    db.set_subscription_status.assert_called_once_with("mem_456", "canceled")
+    db.set_user_tier.assert_called_once_with("u_x", "free")
+
+
+def test_webhook_missing_tier_metadata_400(client):
+    payload = {
+        "action": "membership.activated",
+        "data": {"id": "mem_77", "metadata": {"user_id": "u1"}},  # no tier/cadence
+    }
+    db = MagicMock()
+    with patch("database.get_database_manager", return_value=db):
+        r = _post(client, payload)
+    assert r.status_code == 400
+    db.upsert_subscription.assert_not_called()
+
+
+def test_webhook_unknown_event_type_ignored(client):
+    payload = {"action": "something_else", "data": {}}
+    db = MagicMock()
+    with patch("database.get_database_manager", return_value=db):
+        r = _post(client, payload)
+    assert r.status_code == 200
+    j = r.get_json()
+    assert j.get("ignored") == "something_else"


### PR DESCRIPTION
…ok sync

Adds complete billing infrastructure: three tiers (free/starter/ultra) with quotas on portfolios, watchlists, price alerts, and reports. Whop webhooks are the source of truth; subscriptions table mirrors state for fast lookups.

- Whop API: /api/billing/plans (public), /api/billing/checkout-session (user), /api/billing/webhook (HMAC-SHA256 verified)
- Tier enforcement: 402 errors on portfolio create, watchlist add, alert create when quota exceeded. Legacy is_pro flag synced with tier.
- New src/tiers.py: tier limits, checkout URL builder, cadence derivation
- New src/billing/whop_service.py: webhook signature verification + API fallback
- New SPA pages: Pricing.tsx (public plan grid), UpgradeNudge.tsx (modal component), Settings.tsx plan section
- DB: subscriptions table with RLS, indexes on user_id + status
- Tests: 26 new (test_tiers, test_quota_enforcement, test_whop_webhook); 1 existing updated (test_flask_price_alerts) with tier mock