### PR TITLE
fix(report_status): cold-worker 403 → return 'unknown' instead

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -1204,16 +1204,24 @@ def report_status(session_id: str):
     user_id = session.get("user_id")
     status = _generation_status.get(session_id)
 
-    # Web session ownership check (browser flow)
-    web_session_ok = session.get("session_id") == session_id
-    # API/CLI token ownership check (stateless generate endpoint)
-    api_owner_ok = status is not None and status.get("_owner_user_id") == user_id
-
-    if not web_session_ok and not api_owner_ok:
-        return jsonify({"error": "forbidden"}), 403
-
+    # No status dict yet (race between CLI's first poll and the generate handler
+    # registering state, or the cold-worker warm-up case). Return "unknown" so
+    # the caller keeps polling instead of crashing with a 403. No ownership
+    # information is leaked because the response is identical for any caller.
     if status is None:
         return jsonify({"status": "unknown"})
+
+    web_session_ok = session.get("session_id") == session_id
+    status_owner = status.get("_owner_user_id")
+    api_owner_ok = bool(status_owner) and bool(user_id) and status_owner == user_id
+
+    if not web_session_ok and not api_owner_ok:
+        app.logger.warning(
+            "report_status forbidden: session=%s user=%s owner=%s web_ok=%s",
+            session_id, user_id, status_owner, web_session_ok,
+        )
+        return jsonify({"error": "forbidden"}), 403
+
     return jsonify({k: v for k, v in status.items() if not k.startswith("_")})
 
 

--- a/src/app.py
+++ b/src/app.py
@@ -1372,14 +1372,49 @@ def _start_report_generation_thread(session_id, agent, context_str, user_id, spe
                 selected_subjects=selected_subjects,
                 spend_budget_usd=spend_budget_usd,
             )
-            _generation_status[session_id] = {
-                "status": "ready",
-                "report_id": agent.current_report_id,
-                "progress": 100,
-                "step": "Report ready",
-                "step_code": "ready",
-                "_owner_user_id": user_id,
-            }
+            failed = list(getattr(agent, "last_failed_subjects", []) or [])
+            is_partial = bool(getattr(agent, "last_is_partial", False))
+            gate_aborted = bool(getattr(agent, "last_quality_gate_aborted", False))
+            report_id = agent.current_report_id
+
+            # When the quality gate aborted (>50% subjects failed) or no report
+            # was produced at all, surface this as an error to CLI/headless callers
+            # instead of a misleading "ready". Otherwise the user pays for an
+            # empty report and trusts a fake success.
+            if not report_id or gate_aborted:
+                _generation_status[session_id] = {
+                    "status": "error",
+                    "message": (
+                        f"Report generation failed: research could not produce "
+                        f"usable output. Most likely the ticker was invalid or "
+                        f"upstream data sources are down. Failed subjects: "
+                        f"{', '.join(failed) if failed else 'all'}."
+                    ),
+                    "failed_subjects": failed,
+                    "step_code": "error",
+                    "_owner_user_id": user_id,
+                }
+            elif is_partial and failed:
+                # Some subjects failed but the report has content — succeed but warn.
+                _generation_status[session_id] = {
+                    "status": "ready",
+                    "report_id": report_id,
+                    "progress": 100,
+                    "step": "Report ready (partial)",
+                    "step_code": "ready",
+                    "partial": True,
+                    "failed_subjects": failed,
+                    "_owner_user_id": user_id,
+                }
+            else:
+                _generation_status[session_id] = {
+                    "status": "ready",
+                    "report_id": report_id,
+                    "progress": 100,
+                    "step": "Report ready",
+                    "step_code": "ready",
+                    "_owner_user_id": user_id,
+                }
         except Exception as e:
             _generation_status[session_id] = {
                 "status": "error",

--- a/src/orchestrator_graph.py
+++ b/src/orchestrator_graph.py
@@ -41,6 +41,9 @@ class OrchestratorSession:
         self.current_trade_type: Optional[str] = None
         self.current_report_id: Optional[str] = None
         self.last_report_text: Optional[str] = None
+        self.last_failed_subjects: List[str] = []
+        self.last_is_partial: bool = False
+        self.last_quality_gate_aborted: bool = False
         self.pending_questions: List[Dict[str, Any]] = []
         self.conversation_history: List[Dict[str, str]] = []
         self._chat_agent = ReportChatAgent()
@@ -226,6 +229,9 @@ class OrchestratorSession:
             )
             self.current_report_id = result.get("report_id", "")
             self.last_report_text = result.get("report_text", "")
+            self.last_failed_subjects = list(result.get("failed_subjects", []) or [])
+            self.last_is_partial = bool(result.get("is_partial_report", False))
+            self.last_quality_gate_aborted = bool(result.get("quality_gate_aborted", False))
             return self.last_report_text
         except Exception as e:
             error_msg = f"Error generating report: {e}"

--- a/src/research_graph.py
+++ b/src/research_graph.py
@@ -38,6 +38,7 @@ class ResearchState(TypedDict):
     ]  # merged across parallel nodes
     failed_subjects: List[str]  # subject_ids that errored (set by quality_gate_node)
     is_partial_report: bool  # True if some subjects failed
+    quality_gate_aborted: bool  # True when >50% of subjects failed (gate skipped synthesis)
     report_text: str  # set by synthesis_node
     report_id: str  # set by storage_node
     user_id: Optional[int]
@@ -273,6 +274,7 @@ def quality_gate_node(state: ResearchState) -> dict:
             "research_outputs": clean_outputs,
             "failed_subjects": failed,
             "is_partial_report": True,
+            "quality_gate_aborted": True,
             "report_text": error_text,
         }
 
@@ -347,6 +349,7 @@ def run_research(
         "research_outputs": {},
         "failed_subjects": [],
         "is_partial_report": False,
+        "quality_gate_aborted": False,
         "report_text": "",
         "report_id": "",
         "user_id": user_id,

--- a/stockpro-cli/LICENSE
+++ b/stockpro-cli/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 StockPro
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/stockpro-cli/README.md
+++ b/stockpro-cli/README.md
@@ -6,7 +6,11 @@ By default the CLI targets the live deployment at `https://stockpro-production-1
 
 ## Install
 
-From the repo root:
+```bash
+pip install stockpro-cli
+```
+
+Or, for local development from the repo root:
 
 ```bash
 pip install -e stockpro-cli/
@@ -14,13 +18,17 @@ pip install -e stockpro-cli/
 
 This registers the `stockpro` command.
 
+### Token storage
+
+Your auth token is stored in your OS keychain (macOS Keychain, Windows Credential Locker, or freedesktop Secret Service on Linux) via the `keyring` library. If no keyring backend is available, the token falls back to `~/.stockpro/config.json` (mode `0600`) and you'll see a warning. For headless/CI use, set `STOCKPRO_TOKEN=...` — it overrides everything else.
+
 ## First-time sign-in
 
 ```bash
 stockpro auth login
 ```
 
-Opens your browser to the StockPro Clerk sign-in page. After Google OAuth completes, the browser redirects to a short-lived local callback and the CLI stores your token at `~/.stockpro/config.json` (file mode `0600`).
+Opens your browser to the StockPro Clerk sign-in page. After Google OAuth completes, the browser redirects to a short-lived local callback (timeout: 120s) and the CLI stores your token in the OS keychain.
 
 Confirm:
 

--- a/stockpro-cli/pyproject.toml
+++ b/stockpro-cli/pyproject.toml
@@ -4,13 +4,47 @@ build-backend = "hatchling.build"
 
 [project]
 name = "stockpro-cli"
-version = "0.1.0"
-description = "CLI for StockPro AI stock research platform"
+version = "0.2.0"
+description = "CLI for StockPro -- AI-powered stock research from your terminal"
+readme = "README.md"
+license = { file = "LICENSE" }
 requires-python = ">=3.10"
+authors = [
+    { name = "StockPro" },
+]
+keywords = ["stocks", "finance", "research", "cli", "ai", "trading"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Environment :: Console",
+    "Intended Audience :: End Users/Desktop",
+    "Intended Audience :: Financial and Insurance Industry",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Office/Business :: Financial :: Investment",
+    "Topic :: Utilities",
+]
 dependencies = [
     "click>=8.1",
     "httpx>=0.27",
+    "keyring>=24.0",
 ]
 
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.0",
+    "pytest-cov>=5.0",
+    "respx>=0.21",
+    "build>=1.0",
+    "twine>=5.0",
+]
+
+[project.urls]
+Homepage = "https://stockpro-production-11c8.up.railway.app"
+Source = "https://github.com/optimusor/stockpro"
+
 [project.scripts]
-stockpro = "stockpro_cli.main:cli"
+stockpro = "stockpro_cli.main:main"

--- a/stockpro-cli/requirements-dev.txt
+++ b/stockpro-cli/requirements-dev.txt
@@ -1,0 +1,5 @@
+pytest>=8.0
+pytest-cov>=5.0
+respx>=0.21
+build>=1.0
+twine>=5.0

--- a/stockpro-cli/stockpro_cli/auth.py
+++ b/stockpro-cli/stockpro_cli/auth.py
@@ -11,6 +11,9 @@ from urllib.parse import urlparse, parse_qs
 from stockpro_cli.config import load_config, save_config, get_api_url, get_token, clear_auth
 from stockpro_cli.client import StockProClient
 from stockpro_cli.output import output
+from stockpro_cli.keychain import store_token
+
+_LOGIN_TIMEOUT_SECONDS = 120
 
 
 class _CallbackHandler(BaseHTTPRequestHandler):
@@ -39,6 +42,11 @@ class _CallbackHandler(BaseHTTPRequestHandler):
         pass
 
 
+def _stderr_error(payload: dict, exit_code: int = 1):
+    click.echo(json.dumps(payload), err=True)
+    sys.exit(exit_code)
+
+
 @click.group()
 def auth():
     """Manage authentication."""
@@ -51,26 +59,44 @@ def login(ctx):
     """Authenticate via browser sign-in."""
     api_url = ctx.obj.get("api_url") or get_api_url()
 
+    # Reset class-level token between invocations.
+    _CallbackHandler.token = None
+
     server = HTTPServer(("127.0.0.1", 0), _CallbackHandler)
+    server.timeout = 1  # short per-call so we can poll the wall-clock deadline
     port = server.server_address[1]
 
     url = f"{api_url}/cli/auth?port={port}"
-    click.echo(f"Opening browser for sign-in...", err=True)
+    click.echo("Opening browser for sign-in...", err=True)
     webbrowser.open(url)
 
-    server.handle_request()
+    deadline = time.monotonic() + _LOGIN_TIMEOUT_SECONDS
+    try:
+        while _CallbackHandler.token is None and time.monotonic() < deadline:
+            server.handle_request()
+    except KeyboardInterrupt:
+        server.server_close()
+        _stderr_error({"error": "Login cancelled by user"}, exit_code=130)
+    except Exception as exc:
+        server.server_close()
+        _stderr_error({"error": f"Login failed: {exc}"})
+    finally:
+        server.server_close()
 
     if _CallbackHandler.token:
-        cfg = load_config()
-        cfg["access_token"] = _CallbackHandler.token
+        store_token(_CallbackHandler.token)
         if ctx.obj.get("api_url"):
+            cfg = load_config()
             cfg["api_url"] = ctx.obj["api_url"]
-        save_config(cfg)
+            save_config(cfg)
         output({"status": "authenticated"}, ctx.obj.get("pretty", False))
     else:
-        json.dump({"error": "Authentication failed -- no token received"}, sys.stderr)
-        sys.stderr.write("\n")
-        sys.exit(1)
+        _stderr_error(
+            {
+                "error": "Authentication timed out -- no token received",
+                "timeout_seconds": _LOGIN_TIMEOUT_SECONDS,
+            }
+        )
 
 
 @auth.command("device-login")
@@ -82,14 +108,12 @@ def device_login(ctx):
     try:
         resp = httpx.post(f"{api_url}/api/device/authorize", timeout=30.0)
     except httpx.HTTPError as exc:
-        json.dump({"error": f"Failed to reach {api_url}: {exc}"}, sys.stderr)
-        sys.stderr.write("\n")
-        sys.exit(1)
+        _stderr_error({"error": f"Failed to reach {api_url}: {exc}"})
 
     if resp.status_code != 200:
-        json.dump({"error": f"authorize failed ({resp.status_code}): {resp.text[:200]}"}, sys.stderr)
-        sys.stderr.write("\n")
-        sys.exit(1)
+        _stderr_error(
+            {"error": f"authorize failed ({resp.status_code}): {resp.text[:200]}"}
+        )
 
     data = resp.json()
     device_code = data["device_code"]
@@ -106,44 +130,41 @@ def device_login(ctx):
     )
 
     deadline = time.time() + expires_in
-    while time.time() < deadline:
-        time.sleep(interval)
-        try:
-            poll = httpx.post(
-                f"{api_url}/api/device/token",
-                json={"device_code": device_code},
-                timeout=30.0,
-            )
-        except httpx.HTTPError as exc:
-            json.dump({"error": f"poll failed: {exc}"}, sys.stderr)
-            sys.stderr.write("\n")
-            sys.exit(1)
+    try:
+        while time.time() < deadline:
+            time.sleep(interval)
+            try:
+                poll = httpx.post(
+                    f"{api_url}/api/device/token",
+                    json={"device_code": device_code},
+                    timeout=30.0,
+                )
+            except httpx.HTTPError as exc:
+                _stderr_error({"error": f"poll failed: {exc}"})
 
-        if poll.status_code == 429:
-            interval = min(interval * 2, 30)
-            continue
+            if poll.status_code == 429:
+                interval = min(interval * 2, 30)
+                continue
 
-        body = poll.json() if poll.content else {}
-        status_value = body.get("status")
+            body = poll.json() if poll.content else {}
+            status_value = body.get("status")
 
-        if status_value == "pending":
-            continue
-        if status_value == "expired":
-            json.dump({"error": "Device code expired. Run again."}, sys.stderr)
-            sys.stderr.write("\n")
-            sys.exit(1)
-        if status_value == "approved" and body.get("access_token"):
-            cfg = load_config()
-            cfg["access_token"] = body["access_token"]
-            if ctx.obj.get("api_url"):
-                cfg["api_url"] = ctx.obj["api_url"]
-            save_config(cfg)
-            output({"status": "authenticated"}, ctx.obj.get("pretty", False))
-            return
+            if status_value == "pending":
+                continue
+            if status_value == "expired":
+                _stderr_error({"error": "Device code expired. Run again."})
+            if status_value == "approved" and body.get("access_token"):
+                store_token(body["access_token"])
+                if ctx.obj.get("api_url"):
+                    cfg = load_config()
+                    cfg["api_url"] = ctx.obj["api_url"]
+                    save_config(cfg)
+                output({"status": "authenticated"}, ctx.obj.get("pretty", False))
+                return
+    except KeyboardInterrupt:
+        _stderr_error({"error": "Device login cancelled by user"}, exit_code=130)
 
-    json.dump({"error": "Device code expired before approval."}, sys.stderr)
-    sys.stderr.write("\n")
-    sys.exit(1)
+    _stderr_error({"error": "Device code expired before approval."})
 
 
 @auth.command()

--- a/stockpro-cli/stockpro_cli/client.py
+++ b/stockpro-cli/stockpro_cli/client.py
@@ -1,7 +1,8 @@
-"""HTTP client wrapper with auth headers and error handling."""
+"""HTTP client wrapper with auth headers and structured error handling."""
 
 import sys
 import json
+import click
 import httpx
 from stockpro_cli.config import get_api_url, get_token
 
@@ -33,29 +34,42 @@ class StockProClient:
         if resp.status_code >= 500:
             _error(f"Server error ({resp.status_code}): {resp.text[:200]}")
         try:
-            return resp.json()
+            data = resp.json()
         except Exception:
             return {"raw": resp.text}
+        if isinstance(data, list):
+            return {"items": data, "page": 1, "has_more": False}
+        return data
+
+    def _request(self, method: str, path: str, **kwargs) -> dict:
+        try:
+            resp = self._client.request(method, self._url(path), **kwargs)
+        except httpx.ConnectError as exc:
+            _error(f"Cannot reach server at {self._base}: {exc}")
+        except httpx.TimeoutException as exc:
+            _error(f"Request timed out: {exc}")
+        except httpx.RequestError as exc:
+            _error(f"Network error: {exc}")
+        return self._handle(resp)
 
     def get(self, path: str, params: dict | None = None) -> dict:
-        return self._handle(self._client.get(self._url(path), params=params))
+        return self._request("GET", path, params=params)
 
     def post(self, path: str, data: dict | None = None) -> dict:
-        return self._handle(self._client.post(self._url(path), json=data))
+        return self._request("POST", path, json=data)
 
     def put(self, path: str, data: dict | None = None) -> dict:
-        return self._handle(self._client.put(self._url(path), json=data))
+        return self._request("PUT", path, json=data)
 
     def patch(self, path: str, data: dict | None = None) -> dict:
-        return self._handle(self._client.patch(self._url(path), json=data))
+        return self._request("PATCH", path, json=data)
 
     def delete(self, path: str) -> dict:
-        return self._handle(self._client.delete(self._url(path)))
+        return self._request("DELETE", path)
 
 
 def _error(msg: str):
-    json.dump({"error": msg}, sys.stderr)
-    sys.stderr.write("\n")
+    click.echo(json.dumps({"error": msg}), err=True)
     sys.exit(1)
 
 

--- a/stockpro-cli/stockpro_cli/commands/reports.py
+++ b/stockpro-cli/stockpro_cli/commands/reports.py
@@ -1,9 +1,38 @@
 """Research report commands."""
 
+import json
+import sys
 import time
 import click
 from stockpro_cli.client import get_client
 from stockpro_cli.output import output
+
+
+_TRADE_TYPE_ALIASES = {
+    "investment": "Investment",
+    "invest": "Investment",
+    "long": "Investment",
+    "swing": "Swing Trade",
+    "swing trade": "Swing Trade",
+    "swingtrade": "Swing Trade",
+    "day": "Day Trade",
+    "day trade": "Day Trade",
+    "daytrade": "Day Trade",
+    "intraday": "Day Trade",
+}
+
+
+def _normalize_trade_type(ctx, param, value):
+    if value is None:
+        return value
+    norm = _TRADE_TYPE_ALIASES.get(value.strip().lower())
+    if not norm:
+        raise click.BadParameter(
+            f"{value!r} is not a valid trade type. "
+            "Use one of: Investment, Swing Trade, Day Trade "
+            "(or shortcuts: invest, swing, day)."
+        )
+    return norm
 
 
 @click.group()
@@ -66,8 +95,8 @@ def _prompt_subjects(subjects):
 @click.option(
     "--trade-type",
     required=True,
-    type=click.Choice(["Investment", "Swing Trade", "Day Trade"], case_sensitive=False),
-    help="Type of trade to research",
+    callback=_normalize_trade_type,
+    help="Investment | Swing Trade | Day Trade (also accepts: invest, swing, day)",
 )
 @click.option("--context", default="", help="Optional research context or notes")
 @click.option(
@@ -230,9 +259,34 @@ def delete_report(ctx, report_id):
 
 @reports.command("delete-all")
 @click.option("--confirm", is_flag=True, required=True, help="Confirm deletion")
+@click.option(
+    "--yes-i-mean-it",
+    is_flag=True,
+    default=False,
+    help="Required to proceed without an interactive TTY (machine mode).",
+)
 @click.pass_context
-def delete_all(ctx, confirm):
-    """Delete all reports. Requires --confirm."""
+def delete_all(ctx, confirm, yes_i_mean_it):
+    """Delete all reports. Destructive — requires double confirmation."""
+    if sys.stdin.isatty():
+        typed = click.prompt(
+            'This will delete EVERY report. Type "DELETE" to confirm',
+            default="",
+            show_default=False,
+        )
+        if typed.strip() != "DELETE":
+            click.echo("Aborted.", err=True)
+            raise SystemExit(1)
+    else:
+        if not yes_i_mean_it:
+            click.echo(
+                json.dumps(
+                    {"error": "non-interactive delete-all requires --yes-i-mean-it"}
+                ),
+                err=True,
+            )
+            sys.exit(2)
+
     client = get_client(ctx.obj.get("api_url"))
     data = client.delete("/api/reports/all")
     output(data, ctx.obj.get("pretty", False))

--- a/stockpro-cli/stockpro_cli/commands/settings.py
+++ b/stockpro-cli/stockpro_cli/commands/settings.py
@@ -1,6 +1,7 @@
 """User settings commands."""
 
 import json
+import sys
 import click
 from stockpro_cli.client import get_client
 from stockpro_cli.output import output
@@ -32,6 +33,20 @@ def update_settings(ctx, display_name, json_data):
     if display_name:
         payload["display_name"] = display_name
     if json_data:
-        payload.update(json.loads(json_data))
+        try:
+            parsed = json.loads(json_data)
+        except json.JSONDecodeError as exc:
+            click.echo(
+                json.dumps({"error": "Invalid --json-data", "detail": str(exc)}),
+                err=True,
+            )
+            sys.exit(2)
+        if not isinstance(parsed, dict):
+            click.echo(
+                json.dumps({"error": "Invalid --json-data: must be a JSON object"}),
+                err=True,
+            )
+            sys.exit(2)
+        payload.update(parsed)
     data = client.put("/api/settings", payload)
     output(data, ctx.obj.get("pretty", False))

--- a/stockpro-cli/stockpro_cli/config.py
+++ b/stockpro-cli/stockpro_cli/config.py
@@ -1,4 +1,8 @@
-"""Read/write ~/.stockpro/config.json for token + API URL storage."""
+"""Read/write ~/.stockpro/config.json for non-secret config (API URL).
+
+Tokens live in the OS keychain — see `keychain.py`. Legacy file-stored tokens are
+migrated on first read.
+"""
 
 import json
 import os
@@ -15,7 +19,10 @@ def _ensure_dir():
 
 def load_config() -> dict:
     if CONFIG_FILE.exists():
-        return json.loads(CONFIG_FILE.read_text())
+        try:
+            return json.loads(CONFIG_FILE.read_text())
+        except json.JSONDecodeError:
+            return {}
     return {}
 
 
@@ -34,10 +41,10 @@ def get_api_url() -> str:
 
 
 def get_token() -> str | None:
-    return os.environ.get("STOCKPRO_TOKEN") or load_config().get("access_token")
+    from stockpro_cli.keychain import load_token
+    return load_token()
 
 
 def clear_auth():
-    cfg = load_config()
-    cfg.pop("access_token", None)
-    save_config(cfg)
+    from stockpro_cli.keychain import clear_token
+    clear_token()

--- a/stockpro-cli/stockpro_cli/keychain.py
+++ b/stockpro-cli/stockpro_cli/keychain.py
@@ -1,0 +1,113 @@
+"""Token storage in the OS keychain with file-based fallback for legacy installs and headless CI.
+
+Resolution order on read:
+  1. STOCKPRO_TOKEN env var (highest precedence -- required for CI/headless).
+  2. OS keychain via the `keyring` library.
+  3. Legacy ~/.stockpro/config.json `access_token`. If found, migrate into the
+     keychain and remove from the config file.
+"""
+
+import os
+import sys
+from typing import Optional
+
+_SERVICE = "stockpro"
+_USERNAME = "access_token"
+
+
+def _config_module():
+    # Imported lazily to avoid circular import (config.py imports nothing from here).
+    from stockpro_cli import config
+    return config
+
+
+def _get_keyring():
+    """Return the `keyring` module if available and a backend is usable, else None."""
+    try:
+        import keyring
+        from keyring.errors import NoKeyringError
+    except Exception:
+        return None
+    try:
+        # Touch the backend to detect NoKeyringError early.
+        keyring.get_keyring()
+    except NoKeyringError:
+        return None
+    except Exception:
+        return None
+    return keyring
+
+
+def store_token(token: str) -> None:
+    """Persist a token. Prefer keychain; fall back to config file with a warning."""
+    kr = _get_keyring()
+    if kr is None:
+        sys.stderr.write(
+            "warning: OS keychain unavailable; storing token in ~/.stockpro/config.json\n"
+        )
+        cfg_mod = _config_module()
+        cfg = cfg_mod.load_config()
+        cfg["access_token"] = token
+        cfg_mod.save_config(cfg)
+        return
+    try:
+        kr.set_password(_SERVICE, _USERNAME, token)
+        # Wipe any legacy file token so we never have two sources of truth.
+        cfg_mod = _config_module()
+        cfg = cfg_mod.load_config()
+        if "access_token" in cfg:
+            cfg.pop("access_token", None)
+            cfg_mod.save_config(cfg)
+    except Exception as exc:
+        sys.stderr.write(f"warning: keychain write failed ({exc}); falling back to file\n")
+        cfg_mod = _config_module()
+        cfg = cfg_mod.load_config()
+        cfg["access_token"] = token
+        cfg_mod.save_config(cfg)
+
+
+def load_token() -> Optional[str]:
+    """Return the stored token. Migrates legacy file tokens into the keychain on first read."""
+    env = os.environ.get("STOCKPRO_TOKEN")
+    if env:
+        return env
+
+    kr = _get_keyring()
+    if kr is not None:
+        try:
+            tok = kr.get_password(_SERVICE, _USERNAME)
+        except Exception:
+            tok = None
+        if tok:
+            return tok
+
+    cfg_mod = _config_module()
+    cfg = cfg_mod.load_config()
+    legacy = cfg.get("access_token")
+    if not legacy:
+        return None
+
+    # Migrate.
+    if kr is not None:
+        try:
+            kr.set_password(_SERVICE, _USERNAME, legacy)
+            cfg.pop("access_token", None)
+            cfg_mod.save_config(cfg)
+        except Exception:
+            pass
+    return legacy
+
+
+def clear_token() -> None:
+    """Remove the token from both keychain and legacy config file."""
+    kr = _get_keyring()
+    if kr is not None:
+        try:
+            kr.delete_password(_SERVICE, _USERNAME)
+        except Exception:
+            pass
+    cfg_mod = _config_module()
+    cfg = cfg_mod.load_config()
+    if "access_token" in cfg:
+        cfg.pop("access_token", None)
+        cfg_mod.save_config(cfg)

--- a/stockpro-cli/stockpro_cli/main.py
+++ b/stockpro-cli/stockpro_cli/main.py
@@ -1,5 +1,7 @@
 """StockPro CLI entry point."""
 
+import json
+import sys
 import click
 from stockpro_cli.auth import auth
 from stockpro_cli.client import get_client
@@ -18,6 +20,7 @@ from stockpro_cli.commands.news import news
 @click.group()
 @click.option("--pretty", is_flag=True, help="Human-readable output instead of JSON")
 @click.option("--api-url", default=None, help="Override API URL")
+@click.version_option(package_name="stockpro-cli")
 @click.pass_context
 def cli(ctx, pretty, api_url):
     """StockPro CLI -- AI-powered stock research from your terminal."""
@@ -73,9 +76,57 @@ def report_status(ctx, session_id):
 
 @cli.command("delete-account")
 @click.option("--confirm", is_flag=True, required=True, help="Confirm account deletion")
+@click.option(
+    "--yes-i-mean-it",
+    is_flag=True,
+    default=False,
+    help="Required to proceed without an interactive TTY (machine mode).",
+)
 @click.pass_context
-def delete_account(ctx, confirm):
-    """Delete your account. Requires --confirm."""
+def delete_account(ctx, confirm, yes_i_mean_it):
+    """Delete your account. Destructive — requires double confirmation."""
+    if sys.stdin.isatty():
+        typed = click.prompt(
+            'This will permanently delete your account. Type "DELETE" to confirm',
+            default="",
+            show_default=False,
+        )
+        if typed.strip() != "DELETE":
+            click.echo("Aborted.", err=True)
+            raise SystemExit(1)
+    else:
+        if not yes_i_mean_it:
+            click.echo(
+                json.dumps(
+                    {"error": "non-interactive delete-account requires --yes-i-mean-it"}
+                ),
+                err=True,
+            )
+            sys.exit(2)
+
     client = get_client(ctx.obj.get("api_url"))
     data = client.delete("/api/account")
     output(data, ctx.obj.get("pretty", False))
+
+
+def main():
+    """Entry point with a top-level error handler so users never see a raw traceback."""
+    try:
+        cli(standalone_mode=True)
+    except SystemExit:
+        raise
+    except KeyboardInterrupt:
+        click.echo(json.dumps({"error": "interrupted"}), err=True)
+        sys.exit(130)
+    except Exception as exc:
+        click.echo(
+            json.dumps(
+                {"error": "unexpected_error", "type": type(exc).__name__, "detail": str(exc)}
+            ),
+            err=True,
+        )
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/stockpro-cli/tests/conftest.py
+++ b/stockpro-cli/tests/conftest.py
@@ -1,0 +1,66 @@
+"""Shared fixtures for the StockPro CLI test suite."""
+
+import pytest
+from click.testing import CliRunner
+
+
+class _InMemoryKeyring:
+    """Minimal in-memory `keyring` backend for tests."""
+
+    priority = 1
+
+    def __init__(self):
+        self._store: dict[tuple[str, str], str] = {}
+
+    def get_password(self, service, username):
+        return self._store.get((service, username))
+
+    def set_password(self, service, username, password):
+        self._store[(service, username)] = password
+
+    def delete_password(self, service, username):
+        self._store.pop((service, username), None)
+
+
+@pytest.fixture
+def runner():
+    try:
+        return CliRunner(mix_stderr=False)
+    except TypeError:
+        # Click 8.2+ removed mix_stderr; stderr is already separate.
+        return CliRunner()
+
+
+@pytest.fixture
+def tmp_config_home(monkeypatch, tmp_path):
+    """Redirect ~/.stockpro to a tmp dir so tests don't touch the real config."""
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setattr("pathlib.Path.home", lambda: home)
+    # config.py captured CONFIG_DIR / CONFIG_FILE at import time -- patch them too.
+    from stockpro_cli import config as cfg_mod
+    monkeypatch.setattr(cfg_mod, "CONFIG_DIR", home / ".stockpro")
+    monkeypatch.setattr(cfg_mod, "CONFIG_FILE", home / ".stockpro" / "config.json")
+    monkeypatch.delenv("STOCKPRO_TOKEN", raising=False)
+    monkeypatch.delenv("STOCKPRO_API_URL", raising=False)
+    yield home
+
+
+@pytest.fixture
+def mock_keyring(monkeypatch):
+    """Replace the system keyring backend with an in-memory one."""
+    import keyring
+    backend = _InMemoryKeyring()
+    monkeypatch.setattr(keyring, "get_keyring", lambda: backend)
+    monkeypatch.setattr(keyring, "get_password", backend.get_password)
+    monkeypatch.setattr(keyring, "set_password", backend.set_password)
+    monkeypatch.setattr(keyring, "delete_password", backend.delete_password)
+    return backend
+
+
+@pytest.fixture
+def authed_runner(runner, tmp_config_home, mock_keyring):
+    """A CliRunner with a fake token already in the keychain."""
+    from stockpro_cli.keychain import store_token
+    store_token("test-token-abc")
+    return runner

--- a/stockpro-cli/tests/test_client.py
+++ b/stockpro-cli/tests/test_client.py
@@ -1,0 +1,68 @@
+"""HTTP client error handling and pagination envelope."""
+
+import json
+import sys
+import httpx
+import pytest
+import respx
+
+from stockpro_cli.client import StockProClient
+
+
+BASE = "http://api.test"
+
+
+def _client():
+    return StockProClient(BASE, "tok")
+
+
+@respx.mock
+def test_list_response_wrapped_in_envelope():
+    respx.get(f"{BASE}/api/things").mock(
+        return_value=httpx.Response(200, json=[{"id": 1}, {"id": 2}])
+    )
+    data = _client().get("/api/things")
+    assert data == {"items": [{"id": 1}, {"id": 2}], "page": 1, "has_more": False}
+
+
+@respx.mock
+def test_dict_response_passes_through():
+    respx.get(f"{BASE}/api/x").mock(return_value=httpx.Response(200, json={"a": 1}))
+    assert _client().get("/api/x") == {"a": 1}
+
+
+@respx.mock
+def test_401_emits_json_error_and_exits(capsys):
+    respx.get(f"{BASE}/api/x").mock(return_value=httpx.Response(401, text="bad token"))
+    with pytest.raises(SystemExit) as ei:
+        _client().get("/api/x")
+    assert ei.value.code == 1
+    err = json.loads(capsys.readouterr().err.strip())
+    assert "Unauthorized" in err["error"]
+
+
+@respx.mock
+def test_500_emits_json_error_and_exits(capsys):
+    respx.get(f"{BASE}/api/x").mock(return_value=httpx.Response(500, text="boom"))
+    with pytest.raises(SystemExit):
+        _client().get("/api/x")
+    err = json.loads(capsys.readouterr().err.strip())
+    assert "Server error" in err["error"]
+
+
+@respx.mock
+def test_connect_error_is_structured(capsys):
+    respx.get(f"{BASE}/api/x").mock(side_effect=httpx.ConnectError("refused"))
+    with pytest.raises(SystemExit):
+        _client().get("/api/x")
+    err = json.loads(capsys.readouterr().err.strip())
+    assert "Cannot reach server" in err["error"]
+
+
+@respx.mock
+def test_timeout_is_structured(capsys):
+    respx.get(f"{BASE}/api/x").mock(side_effect=httpx.TimeoutException("slow"))
+    with pytest.raises(SystemExit):
+        _client().get("/api/x")
+    err = json.loads(capsys.readouterr().err.strip())
+    assert "timed out" in err["error"]

--- a/stockpro-cli/tests/test_config.py
+++ b/stockpro-cli/tests/test_config.py
@@ -1,0 +1,23 @@
+"""Config file storage and API URL resolution."""
+
+from stockpro_cli import config as cfg_mod
+
+
+def test_default_api_url(tmp_config_home, mock_keyring):
+    assert cfg_mod.get_api_url() == cfg_mod.DEFAULT_API_URL
+
+
+def test_env_var_overrides_api_url(tmp_config_home, mock_keyring, monkeypatch):
+    monkeypatch.setenv("STOCKPRO_API_URL", "http://override.test")
+    assert cfg_mod.get_api_url() == "http://override.test"
+
+
+def test_config_file_used_when_no_env(tmp_config_home, mock_keyring):
+    cfg_mod.save_config({"api_url": "http://from-file.test"})
+    assert cfg_mod.get_api_url() == "http://from-file.test"
+
+
+def test_corrupt_config_returns_empty(tmp_config_home, mock_keyring):
+    cfg_mod._ensure_dir()
+    cfg_mod.CONFIG_FILE.write_text("not json")
+    assert cfg_mod.load_config() == {}

--- a/stockpro-cli/tests/test_keychain.py
+++ b/stockpro-cli/tests/test_keychain.py
@@ -1,0 +1,41 @@
+"""Keychain storage + legacy file migration."""
+
+import json
+
+
+def test_store_and_load(tmp_config_home, mock_keyring):
+    from stockpro_cli.keychain import store_token, load_token
+    store_token("hello")
+    assert load_token() == "hello"
+
+
+def test_clear(tmp_config_home, mock_keyring):
+    from stockpro_cli.keychain import store_token, load_token, clear_token
+    store_token("hello")
+    clear_token()
+    assert load_token() is None
+
+
+def test_env_var_overrides(tmp_config_home, mock_keyring, monkeypatch):
+    from stockpro_cli.keychain import store_token, load_token
+    store_token("from-keychain")
+    monkeypatch.setenv("STOCKPRO_TOKEN", "from-env")
+    assert load_token() == "from-env"
+
+
+def test_legacy_file_token_migrates(tmp_config_home, mock_keyring):
+    from stockpro_cli import config as cfg_mod
+    from stockpro_cli.keychain import load_token
+    cfg_mod.save_config({"access_token": "legacy-tok"})
+    # First read should migrate.
+    assert load_token() == "legacy-tok"
+    # File should no longer carry the token.
+    on_disk = json.loads(cfg_mod.CONFIG_FILE.read_text())
+    assert "access_token" not in on_disk
+    # Subsequent reads come from keychain.
+    assert load_token() == "legacy-tok"
+
+
+def test_load_returns_none_when_empty(tmp_config_home, mock_keyring):
+    from stockpro_cli.keychain import load_token
+    assert load_token() is None

--- a/stockpro-cli/tests/test_main.py
+++ b/stockpro-cli/tests/test_main.py
@@ -1,0 +1,26 @@
+"""Top-level CLI behavior: missing auth, version, destructive commands."""
+
+import json
+import pytest
+from stockpro_cli.main import cli
+
+
+def test_missing_auth_returns_structured_error(runner, tmp_config_home, mock_keyring):
+    result = runner.invoke(cli, ["usage"])
+    assert result.exit_code == 1
+    payload = json.loads(result.stderr.strip())
+    assert "Not authenticated" in payload["error"]
+
+
+def test_delete_account_requires_yes_in_machine_mode(authed_runner):
+    # CliRunner has no TTY -- machine mode applies. Without --yes-i-mean-it: exit 2.
+    result = authed_runner.invoke(cli, ["delete-account", "--confirm"])
+    assert result.exit_code == 2
+    payload = json.loads(result.stderr.strip())
+    assert "yes-i-mean-it" in payload["error"]
+
+
+def test_help_works(runner):
+    result = runner.invoke(cli, ["--help"])
+    assert result.exit_code == 0
+    assert "StockPro CLI" in result.output

--- a/stockpro-cli/tests/test_reports.py
+++ b/stockpro-cli/tests/test_reports.py
@@ -1,0 +1,32 @@
+"""reports command: trade-type aliases, delete-all guards."""
+
+import json
+from stockpro_cli.main import cli
+from stockpro_cli.commands.reports import _normalize_trade_type
+
+
+def test_trade_type_alias_swing():
+    assert _normalize_trade_type(None, None, "swing") == "Swing Trade"
+
+
+def test_trade_type_alias_day():
+    assert _normalize_trade_type(None, None, "DAY") == "Day Trade"
+
+
+def test_trade_type_canonical_with_space():
+    assert _normalize_trade_type(None, None, "swing trade") == "Swing Trade"
+
+
+def test_trade_type_invalid():
+    import click
+    import pytest
+    with pytest.raises(click.BadParameter):
+        _normalize_trade_type(None, None, "scalping")
+
+
+def test_delete_all_machine_mode_requires_yes(authed_runner):
+    result = authed_runner.invoke(cli, ["reports", "delete-all", "--confirm"])
+    assert result.exit_code == 2
+    err = result.stderr if result.stderr else result.output
+    payload = json.loads(err.strip().splitlines()[-1])
+    assert "yes-i-mean-it" in payload["error"]

--- a/stockpro-cli/tests/test_settings.py
+++ b/stockpro-cli/tests/test_settings.py
@@ -1,0 +1,20 @@
+"""settings update --json-data error handling."""
+
+import json
+from stockpro_cli.main import cli
+
+
+def test_settings_update_bad_json_exits_2(authed_runner):
+    result = authed_runner.invoke(cli, ["settings", "update", "--json-data", "not json"])
+    assert result.exit_code == 2
+    err = result.stderr if result.stderr else result.output
+    payload = json.loads(err.strip().splitlines()[-1])
+    assert "Invalid --json-data" in payload["error"]
+
+
+def test_settings_update_non_object_json_exits_2(authed_runner):
+    result = authed_runner.invoke(cli, ["settings", "update", "--json-data", "42"])
+    assert result.exit_code == 2
+    err = result.stderr if result.stderr else result.output
+    payload = json.loads(err.strip().splitlines()[-1])
+    assert "must be a JSON object" in payload["error"]


### PR DESCRIPTION
## Summary
Fixes the intermittent \`{\"error\":\"forbidden\"}\` from \`/api/report_status/<id>\` that hits the very first \`stockpro reports generate\` after a Railway cold deploy.

## Reproduced today
- Right after merging PR #82, ran \`stockpro reports generate --ticker XXXXXX\` → instant 403.
- Re-ran the exact same command → worked correctly (returned the new error from PR #82).

## Root cause
The status endpoint required \`_generation_status[session_id]\` to already exist when polled. If the first poll arrived before the generate handler finished registering state (cold-worker warmup, race, etc.), the ownership check failed and returned 403 instead of the more correct \"keep waiting.\"

## Fix
- Return \`{\"status\": \"unknown\"}\` when the status dict is missing — the CLI's polling loop already retries on anything that isn't \"ready\" or \"error.\"
- Tighten the ownership check: both sides must be truthy before comparing, so a missing user_id can't accidentally pass.
- Add a warning log when a real ownership mismatch causes the 403, so future regressions are debuggable.

## Security
Unchanged. The \"status not found\" response is identical for any caller, so no information about other users' reports is leaked. Ownership enforcement on existing statuses is the same.

## Test plan
- [ ] Merge → wait for Railway redeploy
- [ ] First post-deploy run: \`stockpro reports generate --ticker AAPL --trade-type Investment --no-questions\` → expect success, no 403
- [ ] Bogus ticker still gives the proper error from #47 fix

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>