### PR TITLE
fix: Nimble run_agent error handling + market sentiment research integration

### DIFF
--- a/src/langchain_tools.py
+++ b/src/langchain_tools.py
@@ -6,6 +6,7 @@ create_all_tools() returns List[StructuredTool] for use with LangGraph agents.
 import json
 import logging
 import math
+import os
 from typing import Dict, Any, List, Optional
 
 from langchain_core.tools import StructuredTool
@@ -15,6 +16,11 @@ from mcp_tools import execute_tool_by_name
 from nimble_client import NimbleClient
 
 logger = logging.getLogger(__name__)
+
+_NIMBLE_X_AGENT_ID = os.getenv("NIMBLE_X_AGENT_ID", "twitter_search_recent_83bb85e3")
+_NIMBLE_REDDIT_AGENT_ID = os.getenv(
+    "NIMBLE_REDDIT_AGENT_ID", "reddit_thread_search_2026_04_20_5y2qc6yy"
+)
 
 
 def _sanitize_nan(obj):
@@ -129,7 +135,7 @@ def create_mcp_tools(mcp_client: MCPClient) -> List[StructuredTool]:
 
 
 def create_nimble_tools(nimble_client: NimbleClient) -> List[StructuredTool]:
-    """Create LangChain StructuredTools for Nimble web search, extract, and Perplexity."""
+    """Create LangChain StructuredTools for Nimble web search, extract, Perplexity, and social sentiment."""
     if not nimble_client:
         return []
 
@@ -238,6 +244,90 @@ def create_nimble_tools(nimble_client: NimbleClient) -> List[StructuredTool]:
                 "suggestion": "Try nimble_web_search for a direct web search, or yfinance tools for financial data.",
             })
 
+    # --- nimble_twitter_sentiment ---
+    class TwitterSentimentArgs(BaseModel):
+        symbol: str = Field(description="Ticker symbol, e.g. 'AAPL' or 'RACE'.")
+        query: str = Field(
+            default="",
+            description=(
+                "Optional custom search query. If empty, defaults to '$SYMBOL'. "
+                "Include company name for less-traded tickers (e.g. 'Ferrari RACE stock')."
+            ),
+        )
+
+    def nimble_twitter_sentiment(symbol: str, query: str = "") -> str:
+        q = query.strip() or f"${symbol}"
+        try:
+            results = nimble_client.run_agent(_NIMBLE_X_AGENT_ID, {"query": q})
+            if not results:
+                return f"No recent tweets found for {symbol}."
+            lines = []
+            for item in results[:15]:
+                inner = item.get("tweet") if isinstance(item.get("tweet"), dict) else item
+                text = (inner.get("full_text") or inner.get("text") or "").strip()[:300]
+                author = inner.get("author") or inner.get("username") or "unknown"
+                likes = inner.get("favorite_count") or inner.get("likes") or 0
+                if text:
+                    lines.append(f"@{author} (\u2665{likes}): {text}")
+            return "\n".join(lines) if lines else f"No usable tweet content found for {symbol}."
+        except Exception as e:
+            logger.warning("[Nimble] twitter_sentiment failed for %s: %s", symbol, e)
+            return f"Twitter sentiment fetch failed for {symbol}: {e}"
+
+    twitter_tool = StructuredTool.from_function(
+        func=nimble_twitter_sentiment,
+        name="nimble_twitter_sentiment",
+        description=(
+            "Fetch recent Twitter/X posts about a stock ticker. "
+            "Use for gauging retail sentiment, identifying trending narratives, "
+            "and catching breaking news or catalyst signals. "
+            "Returns up to 15 recent tweets with author and like count."
+        ),
+        args_schema=TwitterSentimentArgs,
+    )
+
+    # --- nimble_reddit_sentiment ---
+    class RedditSentimentArgs(BaseModel):
+        symbol: str = Field(description="Ticker symbol, e.g. 'AAPL' or 'RACE'.")
+        query: str = Field(
+            default="",
+            description=(
+                "Optional custom search query. If empty, defaults to the symbol. "
+                "Include company name for less-traded tickers."
+            ),
+        )
+
+    def nimble_reddit_sentiment(symbol: str, query: str = "") -> str:
+        q = query.strip() or symbol
+        try:
+            results = nimble_client.run_agent(_NIMBLE_REDDIT_AGENT_ID, {"search_query": q})
+            if not results:
+                return f"No recent Reddit posts found for {symbol}."
+            lines = []
+            for item in results[:15]:
+                title = item.get("title") or item.get("post_title") or ""
+                snippet = (item.get("selftext") or item.get("body") or item.get("snippet") or "")[:250]
+                score = item.get("score") or item.get("upvotes") or 0
+                subreddit = item.get("subreddit") or item.get("community") or "?"
+                if title or snippet:
+                    lines.append(f"r/{subreddit} (\u2191{score}): {title} \u2014 {snippet}".strip(" \u2014"))
+            return "\n".join(lines) if lines else f"No usable Reddit content found for {symbol}."
+        except Exception as e:
+            logger.warning("[Nimble] reddit_sentiment failed for %s: %s", symbol, e)
+            return f"Reddit sentiment fetch failed for {symbol}: {e}"
+
+    reddit_tool = StructuredTool.from_function(
+        func=nimble_reddit_sentiment,
+        name="nimble_reddit_sentiment",
+        description=(
+            "Fetch recent Reddit posts about a stock ticker. "
+            "Use for gauging retail sentiment, community reactions to earnings or news, "
+            "and identifying recurring themes. "
+            "Returns up to 15 recent posts with subreddit and score."
+        ),
+        args_schema=RedditSentimentArgs,
+    )
+
     return [
         StructuredTool.from_function(
             func=nimble_web_search,
@@ -270,6 +360,8 @@ def create_nimble_tools(nimble_client: NimbleClient) -> List[StructuredTool]:
             ),
             args_schema=PerplexityArgs,
         ),
+        twitter_tool,
+        reddit_tool,
     ]
 
 

--- a/src/nimble_client.py
+++ b/src/nimble_client.py
@@ -3,6 +3,7 @@ Nimble API client for web search and content extraction.
 Uses Nimble's SDK REST API with Bearer token authentication.
 """
 
+import logging
 import os
 from typing import Optional, Dict, Any
 
@@ -10,6 +11,8 @@ import httpx
 from dotenv import load_dotenv
 
 load_dotenv()
+
+logger = logging.getLogger(__name__)
 
 NIMBLE_API_BASE = "https://sdk.nimbleway.com/v1"
 NIMBLE_TIMEOUT_SECONDS = float(os.getenv("NIMBLE_TIMEOUT_SECONDS", "60.0"))
@@ -206,5 +209,18 @@ class NimbleClient:
 
                 # Fallback: wrap scalar into a list so callers can iterate safely.
                 return [parsing]
-        except Exception:
+        except httpx.TimeoutException as e:
+            logger.warning(
+                "[Nimble] run_agent '%s' timed out after %ss: %s",
+                agent_name, self.timeout, e,
+            )
+            return []
+        except httpx.HTTPStatusError as e:
+            logger.warning(
+                "[Nimble] run_agent '%s' HTTP %s: %s",
+                agent_name, e.response.status_code, e,
+            )
+            return []
+        except Exception as e:
+            logger.warning("[Nimble] run_agent '%s' failed: %s", agent_name, e)
             return []

--- a/src/research_subjects.py
+++ b/src/research_subjects.py
@@ -398,6 +398,30 @@ Quantify every claim.""",
     priority={"Investment": 2},
 )
 
+MARKET_SENTIMENT = ResearchSubject(
+    id="market_sentiment",
+    name="Market Sentiment",
+    description="Recent Twitter/X and Reddit social sentiment for the ticker",
+    prompt_template="""Research current social media and retail investor sentiment for {ticker}.
+
+Step 1 — Twitter/X: Use nimble_twitter_sentiment with symbol="{ticker}". For less-traded or non-US tickers (e.g. RACE, BABA), also pass the company name in the query field (e.g. "Ferrari RACE stock").
+
+Step 2 — Reddit: Use nimble_reddit_sentiment with symbol="{ticker}". If the symbol alone returns no results, retry with the full company name.
+
+Step 3 — Synthesize a Market Sentiment section covering:
+- Overall sentiment direction: bullish / bearish / mixed / neutral — with 2-3 specific examples from the data
+- Top 2-3 themes or narratives driving discussion (e.g. "short squeeze pressure", "post-earnings disappointment", "AI product launch hype")
+- Any catalyst, news event, or price move that community is reacting to — especially anything from the past 7 days
+- Red flags or outliers worth flagging (e.g. coordinated pumping, unusually high negative sentiment vs. price action)
+
+If one source returns no data, note it briefly ("No recent Reddit discussion found") and rely on the other.
+If both return no data, write: "No recent social sentiment data found for {ticker}."
+Keep the section to 200-300 words.
+""",
+    trade_types=["Day Trade", "Swing Trade", "Investment"],
+    priority={"Day Trade": 1, "Swing Trade": 1, "Investment": 1},
+)
+
 
 # ─── Master List ─────────────────────────────────────────────────────────────
 
@@ -414,6 +438,7 @@ ALL_SUBJECTS: List[ResearchSubject] = [
     COMPETITIVE_POSITION,
     RISK_FACTORS,
     MANAGEMENT_QUALITY,
+    MARKET_SENTIMENT,
 ]
 
 _SUBJECT_MAP: Dict[str, ResearchSubject] = {s.id: s for s in ALL_SUBJECTS}


### PR DESCRIPTION
## Summary

Closes #97 — `run_agent()` silent failure
Closes #98 — Twitter/Reddit sentiment missing from research pipeline

### #97 — `src/nimble_client.py`
- Added `import logging` and `logger = logging.getLogger(__name__)` (was missing entirely)
- Replaced bare `except Exception: return []` (which swallowed all errors with zero logging) with three structured handlers:
  - `httpx.TimeoutException` → `logger.warning` with agent name + timeout seconds
  - `httpx.HTTPStatusError` → `logger.warning` with agent name + HTTP status code
  - `Exception` (catch-all) → `logger.warning` with agent name + error message
- Railway logs will now surface the actual failure mode (4xx, 5xx, timeout) for the first time

### #98 — `src/langchain_tools.py` + `src/research_subjects.py`

**`langchain_tools.py`:**
- Added `import os`
- Added module-level constants `_NIMBLE_X_AGENT_ID` and `_NIMBLE_REDDIT_AGENT_ID` (overridable via env vars)
- Added `nimble_twitter_sentiment` tool inside `create_nimble_tools()` — calls Twitter/X agent, returns up to 15 tweets with author + like count
- Added `nimble_reddit_sentiment` tool inside `create_nimble_tools()` — calls Reddit agent, returns up to 15 posts with subreddit + score
- Both tools are appended to the `create_nimble_tools()` return list

**`src/research_subjects.py`:**
- Added `MARKET_SENTIMENT` subject (priority 1 for all trade types: Day/Swing/Investment)
- Appended to `ALL_SUBJECTS` — `_SUBJECT_MAP` auto-updates, no manual wiring needed
- Prompt template instructs the agent to call both sentiment tools and synthesize a 200–300 word section covering sentiment direction, top narratives, recent catalysts, and red flags

## Test plan
- [ ] Deploy to Railway and run a RACE (Ferrari) report — verify "Market Sentiment" section appears in output
- [ ] Check Railway logs after running any ticker — verify `[Nimble] run_agent` warning lines appear on agent failures instead of silent empty returns
- [ ] Run a report for a major US ticker (AAPL/TSLA) — verify Twitter + Reddit data populates
- [ ] Confirm existing tools (web search, perplexity, yfinance) are unaffected