### PR TITLE
fix(public-view): GET kicks refresh so ticker widget stops looping on 'computing'

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -3892,14 +3892,32 @@ def api_ticker_fundamentals(symbol: str):
 @app.route("/api/ticker/<symbol>/public-view")
 @login_required
 def api_ticker_public_view(symbol: str):
-    """Return cached public-view summary for a symbol (or computing placeholder)."""
+    """Return cached public-view summary for a symbol (or computing placeholder).
+
+    If no row exists yet, or the row is stuck on `status='computing'` with a
+    stale `last_updated` (likely from a prior crashed refresh), kick off a
+    background refresh so the next poll picks up real data instead of looping
+    forever on the placeholder.
+    """
+    import threading as _t
+    from datetime import datetime, timezone, timedelta
     from database import get_database_manager
 
     sym = (symbol or "").strip().upper()
     db = get_database_manager()
     row = db.get_ticker_public_view(sym)
+
+    def _kick_refresh():
+        from watchlist.public_view_service import refresh_public_view
+        _t.Thread(target=refresh_public_view, args=(sym,), daemon=True).start()
+
     if not row:
-        # Not yet computed — return a placeholder so the UI can show a skeleton.
+        # Not yet computed — start a refresh and return a placeholder.
+        try:
+            db.upsert_ticker_public_view(sym, status="computing")
+        except Exception:
+            pass
+        _kick_refresh()
         return jsonify({
             "symbol": sym,
             "status": "computing",
@@ -3911,6 +3929,17 @@ def api_ticker_public_view(symbol: str):
             "last_updated": None,
             "error_message": None,
         })
+
+    # Row exists but stuck on "computing" with stale last_updated — re-kick.
+    if (row.get("status") or "ready") == "computing":
+        last = row.get("last_updated")
+        if last is None:
+            _kick_refresh()
+        else:
+            if last.tzinfo is None:
+                last = last.replace(tzinfo=timezone.utc)
+            if datetime.now(timezone.utc) - last > timedelta(minutes=2):
+                _kick_refresh()
     return jsonify({
         "symbol": sym,
         "status": row.get("status") or "ready",


### PR DESCRIPTION
## Summary

Fixes the ticker page **Public View** widget showing the "Gathering community sentiment from Reddit and X…" spinner forever — even after PR #99 added the research-pipeline sentiment integration.

## Root cause

The widget (`PublicViewCard.tsx`) polls `GET /api/ticker/<sym>/public-view` every 5s while `status === 'computing'`. The GET endpoint returns the placeholder when the DB row is missing or marked computing — **but never started a refresh of its own**. The only triggers were:

- The user manually clicking the "Refresh" button on the widget.
- The 24-hour background `PublicViewRefreshJob`, which only touches symbols on a user's watchlist.

So for any ticker that wasn't on a watchlist, or any row stuck on `computing` because an earlier refresh thread died mid-flight (e.g. during a Railway redeploy), the widget would poll forever and Nimble was never called. Railway logs confirmed: grep for `public_view` / `nimble` / `run_agent` returned **zero matches** after the latest deploy — meaning no refresh actually ran.

## Fix

In `api_ticker_public_view` (`src/app.py`):

- If the row is **missing**, mark it `computing` and spawn a background `refresh_public_view(sym)` thread, then return the placeholder.
- If the row exists with `status='computing'` and `last_updated` is older than **2 minutes** (or null), re-kick a refresh thread. Fresh "computing" rows from an in-flight refresh are left alone.

This is the same daemon-thread pattern the `/refresh` POST route already uses.

## Test plan

- [ ] Open RACE ticker page → Public View widget transitions from "Gathering…" to real Reddit + X posts within ~30s.
- [ ] Railway logs show `public_view: RACE raw_reddit=N raw_x=N display_name=...` after the GET.
- [ ] Verified with agent-browser MutationObserver capture on the production page.
- [ ] Existing `/refresh` button behavior unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)