### PR TITLE
fix: re-prime agent ticker in start_generation to survive multi-worker routing (#116)

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -1197,6 +1197,26 @@ def start_generation():
     agent.user_id = session.get("user_id")
     agent.username = session.get("username")
 
+    # Re-prime the agent's ticker/trade_type from the Flask session cookie when
+    # this worker's in-memory agent is fresh. popup_start runs start_research on
+    # whichever gunicorn worker served it; start_generation can land on a
+    # different worker whose agent_sessions has no primed agent (issue #116).
+    # The signed cookie is shared across workers, so it restores the state.
+    if not agent.current_ticker:
+        _ct = (session.get("current_ticker") or "").strip().upper()
+        _tt = (session.get("current_trade_type") or "").strip()
+        if _ct and _tt:
+            agent.current_ticker = _ct
+            agent.current_trade_type = _tt
+
+    # If the ticker still cannot be recovered, fail loudly instead of marking the
+    # job "ready" with no report (the silent no-op users hit under multi-worker).
+    if not agent.current_ticker or not agent.current_trade_type:
+        return (
+            jsonify({"error": "No active research session. Please restart the report."}),
+            400,
+        )
+
     # Set user language preference for Hebrew report generation
     try:
         from database import get_database_manager

--- a/tests/test_flask_research_ajax.py
+++ b/tests/test_flask_research_ajax.py
@@ -174,6 +174,70 @@ def test_start_generation_returns_success_and_schedules_thread(api_client):
     mock_thread.start.assert_called_once()
 
 
+def test_start_generation_reprimes_ticker_from_session_when_agent_fresh(api_client):
+    """Cross-worker case (#116): the agent has no in-memory ticker, but the
+    Flask cookie carries it from popup_start. start_generation must restore it
+    and proceed instead of silently no-opping."""
+    import app as app_module
+
+    # Fresh agent on a different worker — no primed ticker/trade_type.
+    mock_agent = MagicMock()
+    mock_agent.current_ticker = None
+    mock_agent.current_trade_type = None
+    mock_thread = MagicMock()
+
+    with patch.object(app_module, "_session_hits_report_quota", return_value=False):
+        with patch.object(app_module, "initialize_session", return_value=mock_agent):
+            with patch.object(app_module, "get_or_create_session_id", return_value="sid-reprime"):
+                with patch("spend_budget.get_spend_budget_usd", return_value=2.5):
+                    with patch.object(app_module.threading, "Thread", return_value=mock_thread):
+                        with api_client.session_transaction() as sess:
+                            sess["user_id"] = "u1"
+                            sess["username"] = "nu"
+                            sess["current_ticker"] = "TEVA.TA"
+                            sess["current_trade_type"] = "Investment"
+                        resp = api_client.post(
+                            "/start_generation",
+                            json={"questions": ["Q?"], "answers": ["A"]},
+                            content_type="application/json",
+                        )
+
+    assert resp.status_code == 200
+    assert resp.get_json() == {"success": True}
+    # Agent was re-primed from the cookie, so generation can run.
+    assert mock_agent.current_ticker == "TEVA.TA"
+    assert mock_agent.current_trade_type == "Investment"
+    mock_thread.start.assert_called_once()
+
+
+def test_start_generation_400_when_no_active_session_anywhere(api_client):
+    """If neither the in-memory agent nor the cookie has a ticker, fail loudly
+    (400) rather than marking the job 'ready' with no report (#116)."""
+    import app as app_module
+
+    mock_agent = MagicMock()
+    mock_agent.current_ticker = None
+    mock_agent.current_trade_type = None
+    mock_thread = MagicMock()
+
+    with patch.object(app_module, "_session_hits_report_quota", return_value=False):
+        with patch.object(app_module, "initialize_session", return_value=mock_agent):
+            with patch.object(app_module, "get_or_create_session_id", return_value="sid-none"):
+                with patch.object(app_module.threading, "Thread", return_value=mock_thread):
+                    with api_client.session_transaction() as sess:
+                        sess["user_id"] = "u1"
+                        sess["username"] = "nu"
+                    resp = api_client.post(
+                        "/start_generation",
+                        json={"questions": ["Q?"], "answers": ["A"]},
+                        content_type="application/json",
+                    )
+
+    assert resp.status_code == 400
+    assert "error" in resp.get_json()
+    mock_thread.start.assert_not_called()
+
+
 class TestPositionCheckApi:
     def test_returns_positions_for_authenticated_user(self, api_client):
         import app as app_module


### PR DESCRIPTION
## Summary
- The SPA report flow splits across `/popup_start` (primes the agent's ticker via `start_research`) and `/start_generation` (generates). The agent lives in a **per-gunicorn-worker** in-memory `agent_sessions` dict, so when the two requests hit different workers (`gunicorn -w 4`), `start_generation` got a fresh agent with no ticker. `generate_report()` then returned `"Error: No active research session."` **without raising**, so the job was marked `ready` with `report_id=NULL` and **no report was produced** (silent no-op).
- Fix: `start_generation` now restores `current_ticker`/`current_trade_type` from the cross-worker **Flask session cookie** when the in-memory agent is fresh, and returns a **400** instead of a silent `ready` when no ticker can be recovered.

## Evidence (production, 2026-06-10)
```
18:50:33  POST /popup_start       pid=<4>   (primed agent on worker 4)
18:52:48  POST /start_generation  pid=<5>   (fresh agent on worker 5 -> no ticker)
```
Result in DB: `generation_status` = `ready`, `report_id=NULL`; no `reports` row, no `report_chunks`. The pipeline never ran.

## Test plan
- [x] `tests/test_flask_research_ajax.py` new: `test_start_generation_reprimes_ticker_from_session_when_agent_fresh` (cross-worker recovery) and `test_start_generation_400_when_no_active_session_anywhere` (loud failure) -- both pass.
- [x] Existing `start_generation`/`popup_start` tests still pass.
- [ ] Note: a pre-existing unrelated failure in the same file (`TestPositionCheckApi::test_returns_empty_when_no_holdings`, stale `holding` key) is red on `main` too -- not touched here.

## Notes
- Same-worker path is unchanged: the re-prime only runs when `current_ticker` is empty.
- Only the stateful web path is affected. `/api/reports/generate` (CLI) already primes in-request and is untouched.
- Unblocks a clean browser e2e of #113 (the TASE gate fix), which previously short-circuited on this bug.
- Relates to #85 (systemic fix: move per-session state out of per-worker memory).

Closes #116