### PR TITLE
fix: make create_user idempotent with ON CONFLICT DO NOTHING (#103)

### DIFF
--- a/src/database.py
+++ b/src/database.py
@@ -1287,14 +1287,17 @@ class DatabaseManager:
                     """
                     INSERT INTO users (user_id, username, email, email_hash, password_hash, google_id)
                     VALUES (%s, %s, %s, %s, %s, %s)
+                    ON CONFLICT (user_id) DO NOTHING
                 """,
                     (user_id, username, encrypt(email), hmac_email(email), password_hash, google_id),
                 )
+                created = cur.rowcount == 1
             conn.commit()
-            try:
-                self.admin_log_event("signup", user_id, {"username": username})
-            except Exception:
-                pass
+            if created:
+                try:
+                    self.admin_log_event("signup", user_id, {"username": username})
+                except Exception:
+                    pass
         except psycopg2.Error as e:
             if conn:
                 conn.rollback()

--- a/tests/test_create_user_idempotent.py
+++ b/tests/test_create_user_idempotent.py
@@ -1,0 +1,62 @@
+"""
+create_user() must be idempotent (issue #103).
+
+The auth middleware calls create_user() whenever it sees no row for a user.
+Parallel requests (multi-tab login) can both pass that check and both INSERT
+the same user_id, so the INSERT must carry ON CONFLICT (user_id) DO NOTHING
+or the losing request raises UniqueViolation and 500s every endpoint.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from database import DatabaseManager
+
+
+def _make_manager(rowcount):
+    mgr = DatabaseManager.__new__(DatabaseManager)
+    mock_cur = MagicMock()
+    mock_cur.rowcount = rowcount
+    mock_conn = MagicMock()
+    ctx = MagicMock()
+    ctx.__enter__.return_value = mock_cur
+    ctx.__exit__.return_value = None
+    mock_conn.cursor.return_value = ctx
+    return mgr, mock_cur, mock_conn
+
+
+def _run_create_user(mgr, mock_conn):
+    with patch.object(mgr, "get_connection", return_value=mock_conn):
+        with patch.object(mgr, "_release"):
+            with patch("database.encrypt", return_value="enc"):
+                with patch("database.hmac_email", return_value="hash"):
+                    mgr.admin_log_event = MagicMock()
+                    mgr.create_user(
+                        user_id="user-1", username="alice", email="a@b.com"
+                    )
+    return mgr.admin_log_event
+
+
+def test_insert_uses_on_conflict_do_nothing():
+    mgr, mock_cur, mock_conn = _make_manager(rowcount=1)
+    _run_create_user(mgr, mock_conn)
+
+    mock_cur.execute.assert_called_once()
+    sql = mock_cur.execute.call_args[0][0]
+    assert "ON CONFLICT (user_id) DO NOTHING" in sql
+
+
+def test_signup_logged_on_first_insert():
+    mgr, mock_cur, mock_conn = _make_manager(rowcount=1)
+    log = _run_create_user(mgr, mock_conn)
+
+    log.assert_called_once_with("signup", "user-1", {"username": "alice"})
+    mock_conn.commit.assert_called_once()
+
+
+def test_signup_not_logged_on_duplicate_insert():
+    """rowcount 0 means the row already existed — no second signup event."""
+    mgr, mock_cur, mock_conn = _make_manager(rowcount=0)
+    log = _run_create_user(mgr, mock_conn)
+
+    log.assert_not_called()
+    mock_conn.commit.assert_called_once()


### PR DESCRIPTION
Closes #103

## Summary
- create_user() in src/database.py now uses ON CONFLICT (user_id) DO NOTHING, so parallel requests for the same new user (multi-tab login, token refresh) no longer raise UniqueViolation and 500 every endpoint for that session.
- The signup admin_log_event now fires only on a genuine first insert (cur.rowcount == 1), not on no-op re-inserts.
- New test file tests/test_create_user_idempotent.py covers the ON CONFLICT clause and signup-event behavior.

## Test plan
- [x] tests/test_create_user_idempotent.py — 3/3 pass
- [x] Full suite run locally: all failures are pre-existing (legacy Jinja page-render tests, TELEGRAM_BOT_TOKEN env tests, _released_lock fixture drift from the pool pre-ping change) — none touch create_user
- [x] tests/test_price_cache_fastlane.py excluded locally: several of its tests hang on real network calls past their mocks (tracked separately)