### PR TITLE
fix: guard empty portfolios in /api/portfolios/prices (#104)

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -2333,6 +2333,15 @@ def portfolios_prices():
             }, 0.0, 0.0, 0.0
 
     pids = [p["portfolio_id"] for p in portfolios]
+
+    # Guard: new users have no portfolios. ThreadPoolExecutor(max_workers=0)
+    # raises ValueError, so return an empty result immediately.
+    if not pids:
+        return jsonify({
+            "portfolios": [],
+            "totals": {"total_value": 0.0, "total_pnl": 0.0, "day_change": 0.0},
+        })
+
     with ThreadPoolExecutor(max_workers=min(len(pids), 5)) as pool:
         futures = {pid: pool.submit(_fetch_summary, pid) for pid in pids}
 

--- a/tests/test_flask_api_routes.py
+++ b/tests/test_flask_api_routes.py
@@ -202,6 +202,24 @@ class TestPortfolioApiJson:
         assert rows[0]["total_market_value"] == 100.0
         assert "totals" in data
 
+    def test_portfolios_prices_empty_returns_zero_totals(self, api_client):
+        import app as app_module
+
+        mock_svc = MagicMock()
+        mock_svc.list_portfolios.return_value = []
+        with patch.object(app_module, "get_portfolio_service", return_value=mock_svc):
+            with api_client.session_transaction() as sess:
+                sess["user_id"] = "me"
+            resp = api_client.get("/api/portfolios/prices")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["portfolios"] == []
+        assert data["totals"] == {
+            "total_value": 0.0,
+            "total_pnl": 0.0,
+            "day_change": 0.0,
+        }
+
     def test_portfolio_history_404_when_not_owner(self, api_client):
         import app as app_module
 


### PR DESCRIPTION
## Summary
- New users with zero portfolios crashed on first dashboard load: `/api/portfolios/prices` built `ThreadPoolExecutor(max_workers=min(len(pids), 5))`, which is `max_workers=0` when `pids` is empty, raising `ValueError` (500).
- Added an early return with zeroed totals when there are no portfolios — semantically identical to the executor path's zero-portfolio result, and avoids spinning up a thread pool for nothing.
- Added a regression test (`test_portfolios_prices_empty_returns_zero_totals`).

## Test plan
- [x] `python -m pytest tests/test_flask_api_routes.py` — 14 passed (13 existing + 1 new)
- [x] Full suite (excluding the known-hanging `test_price_cache_fastlane.py`) — only the documented pre-existing failures remain; no new regressions

Closes #104