### PR TITLE
fix: surface report storage failures instead of fake "ready" (#102)

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -1307,14 +1307,29 @@ def start_generation():
                 selected_subjects=selected_subject_ids,
                 spend_budget_usd=spend_budget_usd,
             )
-            db.update_generation_status(
-                session_id,
-                status="ready",
-                report_id=agent.current_report_id,
-                progress=100,
-                step="Report ready",
-                step_code="ready",
-            )
+            # Guard against a missing report_id: storage can fail without
+            # raising (it logs research_failed and clears report_id), so an
+            # empty id here means no report was saved. Surface an error rather
+            # than a misleading "ready" with no report behind it (issue #102).
+            if not agent.current_report_id:
+                db.update_generation_status(
+                    session_id,
+                    status="error",
+                    message=(
+                        "Report generation failed: the research ran but the "
+                        "report could not be saved. Please try again."
+                    ),
+                    step_code="error",
+                )
+            else:
+                db.update_generation_status(
+                    session_id,
+                    status="ready",
+                    report_id=agent.current_report_id,
+                    progress=100,
+                    step="Report ready",
+                    step_code="ready",
+                )
         except Exception as e:
             db.update_generation_status(
                 session_id,

--- a/src/research_graph.py
+++ b/src/research_graph.py
@@ -206,11 +206,15 @@ def storage_node(state: ResearchState) -> dict:
         except Exception:
             pass
     except Exception as e:
-        logger.warning("Storage failed (report still available): %s", e)
+        logger.warning("Storage failed, no report saved: %s", e)
+        # Storage failed: the pre-generated report_id points to no DB row, so
+        # clear it. A non-empty orphan id would let callers report a fake
+        # "ready" status with no report behind it (issue #102).
+        report_id = ""
         try:
             from database import get_database_manager
             _db = get_database_manager()
-            _db.admin_log_event("research_complete", user_id, {
+            _db.admin_log_event("research_failed", user_id, {
                 "ticker": ticker, "status": "error", "error": str(e)[:200],
             })
         except Exception:

--- a/tests/test_research_graph_checkpointer.py
+++ b/tests/test_research_graph_checkpointer.py
@@ -446,3 +446,52 @@ def test_storage_node_completeness_flag_partial(monkeypatch):
 
     assert captured["metadata"]["completeness"] == "partial"
     assert captured["metadata"]["failed_subjects"] == ["company_overview"]
+
+
+def test_storage_node_failure_clears_report_id_and_logs_research_failed(monkeypatch):
+    """When store_report raises, storage_node returns an empty report_id and logs
+    a 'research_failed' event (not 'research_complete') so callers cannot report a
+    fake 'ready' status with no saved report behind it (issue #102)."""
+    import research_graph as rg
+    import sys
+    from unittest.mock import MagicMock
+
+    # ReportStorage.store_report blows up (simulates a DB/storage failure).
+    mock_storage = MagicMock()
+    mock_storage.store_report.side_effect = RuntimeError("storage exploded")
+    fake_storage_module = MagicMock()
+    fake_storage_module.ReportStorage = lambda: mock_storage
+    monkeypatch.setitem(sys.modules, "report_storage", fake_storage_module)
+
+    # Capture admin events emitted during the failure path.
+    events = []
+    fake_db = MagicMock()
+    fake_db.admin_log_event.side_effect = lambda event_type, user_id, payload: (
+        events.append((event_type, payload))
+    )
+    fake_db_module = MagicMock()
+    fake_db_module.get_database_manager = lambda: fake_db
+    monkeypatch.setitem(sys.modules, "database", fake_db_module)
+
+    plan = MagicMock()
+    plan.selected_subject_ids = ["news_catalysts"]
+    plan.trade_context = ""
+    plan.planner_reasoning = ""
+
+    result = rg.storage_node({
+        "ticker": "HMM.A.TA",
+        "trade_type": "investment",
+        "report_text": "synthesized report body",
+        "plan": plan,
+        "user_id": "user_123",
+        "emitter": None,
+        "is_partial_report": False,
+        "failed_subjects": [],
+    })
+
+    # No DB row was saved, so the returned report_id must be falsy.
+    assert result["report_id"] == ""
+    # The event must be 'research_failed', never a 'research_complete'.
+    event_types = [e[0] for e in events]
+    assert "research_failed" in event_types
+    assert "research_complete" not in event_types


### PR DESCRIPTION
## Summary

Fixes #102 — a user triggered a `research_complete` event but had no saved report. Root cause is a silent storage failure that still reported success.

- When `store_report()` fails inside `storage_node` (`src/research_graph.py`), the `except` block swallowed the exception, logged a `research_complete` event with `status="error"`, and returned the pre-generated **orphan** `report_id` (a `uuid4()` that was never written to the DB).
- The web report flow (`run_generation` in `src/app.py`) then wrote `status="ready"` with that orphan id — so the user saw "ready" + a report_id, but no report row existed.

## Changes

- **`src/research_graph.py`** — on storage failure, clear `report_id` to `""` and emit **`research_failed`** instead of `research_complete`, so the analytics signal is honest and the orphan id can't propagate.
- **`src/app.py`** — the web `run_generation` now guards on an empty `agent.current_report_id` and writes `status="error"` instead of `status="ready"` (mirroring the guard the CLI flow at `_start_report_generation_thread` already had). Incidentally hardens #48.
- **`tests/test_research_graph_checkpointer.py`** — regression test: when `store_report` raises, `storage_node` returns an empty `report_id` and logs `research_failed` (never `research_complete`).

## Test plan

- [x] `python -m pytest tests/test_research_graph_checkpointer.py` — 23 passed (incl. new regression test)
- [x] Full suite (excl. known-hanging `test_price_cache_fastlane.py`): 449 passed; the 34 failures are pre-existing legacy-Jinja route tests (verified identical failures on clean `main`), unrelated to this change
- [ ] Frontend not exercised — the SPA already handles `status="error"` (the existing `except` path produces it), so no UI change was needed

## Note

The admin stats query counts `research_complete` events; previously, error-status completions were miscounted as successes. They now register as `research_failed` — a metric correction, not a regression.

Closes #102