### PR TITLE
fix: retry stale Supabase DB connections instead of 500ing (#110)

### DIFF
--- a/src/database.py
+++ b/src/database.py
@@ -110,6 +110,110 @@ class DatabaseManager:
             except Exception:
                 pass
 
+    # Total checkout attempts for a single read/write operation. One retry is
+    # enough: the issue is a connection silently dropped by Supabase, and it
+    # self-resolves on the next fresh connection. Deliberately not higher, so a
+    # genuine outage fails fast instead of stacking 30s statement_timeouts.
+    _MAX_DB_TRIES = 2
+
+    # Substring backstop for psycopg2.OperationalError raised when Supabase has
+    # dropped the socket. The robust signal is conn.closed != 0 (set after the
+    # error); these markers catch the case where the drop is reported before the
+    # connection object flips closed. Lowercased at compare time.
+    _DROPPED_CONN_MARKERS = (
+        "ssl connection has been closed unexpectedly",
+        "server closed the connection unexpectedly",
+        "connection already closed",
+        "connection not open",
+        "no connection to the server",
+        "terminating connection due to",
+        "could not receive data from server",
+        "could not send data to server",
+    )
+
+    @classmethod
+    def _is_dropped_connection(cls, conn, exc) -> bool:
+        """True only when the connection was dropped underneath us -- not for a
+        genuine query error like a statement timeout (QueryCanceled subclasses
+        OperationalError but leaves the connection open, so it must NOT retry)."""
+        if not isinstance(exc, psycopg2.OperationalError):
+            return False
+        if conn is not None and getattr(conn, "closed", 0):
+            return True
+        msg = str(exc).lower()
+        return any(marker in msg for marker in cls._DROPPED_CONN_MARKERS)
+
+    def _discard(self, conn):
+        """Drop a poisoned connection so the pool replaces it on next checkout."""
+        try:
+            self._pool.putconn(conn, close=True)
+        except Exception:
+            pass
+        with self._released_lock:
+            self._released_at.pop(id(conn), None)
+
+    def _run_read(self, operation):
+        """Run a read-only operation(conn) with one transparent retry if the
+        pooled connection was dropped mid-query. Safe for SELECTs only: a read
+        that fails on a dead socket never reached the server, so re-running it on
+        a fresh connection cannot double-apply anything."""
+        last_err = None
+        for attempt in range(self._MAX_DB_TRIES):
+            conn = self.get_connection()
+            try:
+                return operation(conn)
+            except psycopg2.OperationalError as e:
+                if not self._is_dropped_connection(conn, e):
+                    raise  # real query error -- let it surface, conn released below
+                last_err = e
+                self._discard(conn)
+                conn = None
+                if attempt + 1 < self._MAX_DB_TRIES:
+                    logger.warning(
+                        "DB read hit a dropped connection; retrying on a fresh one"
+                    )
+                    continue
+                raise
+            finally:
+                if conn is not None:
+                    self._release(conn)
+        raise last_err
+
+    def _run_write(self, operation):
+        """Run a write operation(conn) and commit, with one transparent retry if
+        the connection was dropped BEFORE the commit. A pre-commit failure never
+        reached durable state, so the retry is safe. A failure during commit()
+        itself is ambiguous (the server may have committed before the socket
+        died), so commit() lives outside the retryable block and is never retried
+        -- that is what stops a committed-but-unacked write from double-applying."""
+        last_err = None
+        for attempt in range(self._MAX_DB_TRIES):
+            conn = self.get_connection()
+            try:
+                try:
+                    result = operation(conn)
+                except psycopg2.OperationalError as e:
+                    # Failure before commit: nothing durable happened.
+                    if not self._is_dropped_connection(conn, e):
+                        raise  # real query error -- surface it
+                    last_err = e
+                    self._discard(conn)
+                    conn = None
+                    if attempt + 1 < self._MAX_DB_TRIES:
+                        logger.warning(
+                            "DB write hit a dropped connection pre-commit; retrying"
+                        )
+                        continue
+                    raise
+                # operation succeeded; the commit is the ambiguous part. It is
+                # intentionally outside the retry path above.
+                conn.commit()
+                return result
+            finally:
+                if conn is not None:
+                    self._release(conn)
+        raise last_err
+
     def init_schema(self):
         """Initialize database schema (create tables if they don't exist)."""
         conn = None
@@ -2857,8 +2961,7 @@ class DatabaseManager:
     def upsert_price_cache(
         self, symbol, asset_type, price, change_percent, display_name=None, currency="USD"
     ):
-        conn = self.get_connection()
-        try:
+        def op(conn):
             with conn.cursor() as cur:
                 cur.execute(
                     """
@@ -2873,9 +2976,8 @@ class DatabaseManager:
                 """,
                     (symbol, asset_type, price, change_percent, display_name, currency),
                 )
-            conn.commit()
-        finally:
-            self._release(conn)
+
+        self._run_write(op)
         try:
             if os.getenv("STOCKPRO_ALERT_EVAL_ENABLED", "true").lower() in (
                 "1",
@@ -3091,8 +3193,8 @@ class DatabaseManager:
         if not symbols:
             return []
         norm = [s.upper() for s in symbols]
-        conn = self.get_connection()
-        try:
+
+        def op(conn):
             with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
                 cur.execute(
                     """
@@ -3102,8 +3204,8 @@ class DatabaseManager:
                     (norm,),
                 )
                 return list(cur.fetchall())
-        finally:
-            self._release(conn)
+
+        return self._run_read(op)
 
     def record_price_alert_trigger(
         self,
@@ -3113,9 +3215,7 @@ class DatabaseManager:
         symbol: str,
         body: str,
     ) -> None:
-        conn = None
-        try:
-            conn = self.get_connection()
+        def op(conn):
             with conn.cursor() as cur:
                 cur.execute(
                     """
@@ -3133,20 +3233,16 @@ class DatabaseManager:
                     """,
                     (alert_id,),
                 )
-            conn.commit()
+
+        try:
+            self._run_write(op)
         except psycopg2.Error as e:
-            if conn:
-                conn.rollback()
             raise RuntimeError(f"Failed to record price alert trigger: {e}")
-        finally:
-            if conn:
-                self._release(conn)
 
     def list_price_alert_notifications_for_user(
         self, user_id: str, limit: int = 50
     ) -> List[Dict[str, Any]]:
-        conn = self.get_connection()
-        try:
+        def op(conn):
             with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
                 cur.execute(
                     """
@@ -3158,12 +3254,11 @@ class DatabaseManager:
                     (user_id, limit),
                 )
                 return list(cur.fetchall())
-        finally:
-            self._release(conn)
+
+        return self._run_read(op)
 
     def count_unread_price_alert_notifications(self, user_id: str) -> int:
-        conn = self.get_connection()
-        try:
+        def op(conn):
             with conn.cursor() as cur:
                 cur.execute(
                     """
@@ -3174,15 +3269,13 @@ class DatabaseManager:
                 )
                 row = cur.fetchone()
                 return int(row[0]) if row else 0
-        finally:
-            self._release(conn)
+
+        return self._run_read(op)
 
     def mark_price_alert_notification_read(
         self, notification_id: str, user_id: str
     ) -> bool:
-        conn = None
-        try:
-            conn = self.get_connection()
+        def op(conn):
             with conn.cursor() as cur:
                 cur.execute(
                     """
@@ -3192,16 +3285,12 @@ class DatabaseManager:
                     """,
                     (notification_id, user_id),
                 )
-                ok = cur.rowcount > 0
-            conn.commit()
-            return ok
+                return cur.rowcount > 0
+
+        try:
+            return self._run_write(op)
         except psycopg2.Error as e:
-            if conn:
-                conn.rollback()
             raise RuntimeError(f"Failed to mark notification read: {e}")
-        finally:
-            if conn:
-                self._release(conn)
 
     def mark_all_price_alert_notifications_read(self, user_id: str) -> int:
         conn = None

--- a/tests/test_db_stale_connection.py
+++ b/tests/test_db_stale_connection.py
@@ -1,0 +1,192 @@
+"""
+_run_read / _run_write: a pooled connection silently dropped by Supabase
+(SSL connection closed) surfaces as psycopg2.OperationalError mid-query. The
+helpers must transparently retry on a fresh connection where it is provably
+safe to do so, and must NOT retry genuine query errors or post-commit failures.
+
+See issue #110.
+"""
+
+import threading
+
+import psycopg2
+from unittest.mock import MagicMock
+
+from database import DatabaseManager
+
+
+def _dropped_error():
+    return psycopg2.OperationalError("SSL connection has been closed unexpectedly")
+
+
+def _make_conn(closed=0):
+    conn = MagicMock()
+    conn.closed = closed
+    return conn
+
+
+def _bare_manager():
+    """A DatabaseManager with just the retry bookkeeping wired up (no real pool)."""
+    mgr = DatabaseManager.__new__(DatabaseManager)
+    mgr._released_at = {}
+    mgr._released_lock = threading.Lock()
+    mgr._pool = MagicMock()
+    return mgr
+
+
+def _wire_connections(mgr, conns):
+    """get_connection hands out the given connections in order; _release is a no-op
+    we can assert on."""
+    mgr.get_connection = MagicMock(side_effect=list(conns))
+    mgr._release = MagicMock()
+    return mgr
+
+
+# ── reads ────────────────────────────────────────────────────────────────
+
+
+def test_run_read_retries_on_dropped_connection():
+    dead = _make_conn()
+    healthy = _make_conn()
+    mgr = _wire_connections(_bare_manager(), [dead, healthy])
+
+    calls = []
+
+    def op(conn):
+        calls.append(conn)
+        if conn is dead:
+            # psycopg2 flips conn.closed after the failed execute.
+            conn.closed = 1
+            raise _dropped_error()
+        return "rows"
+
+    assert mgr._run_read(op) == "rows"
+    assert calls == [dead, healthy]
+    # The poisoned connection is discarded so the pool replaces it; the healthy
+    # one is released normally, never force-closed.
+    mgr._pool.putconn.assert_called_once_with(dead, close=True)
+    mgr._release.assert_called_once_with(healthy)
+
+
+def test_run_read_does_not_retry_real_query_error():
+    """A statement timeout (QueryCanceled subclasses OperationalError) leaves the
+    connection open -- it must surface, not retry, not force-close the conn."""
+    conn = _make_conn()
+    mgr = _wire_connections(_bare_manager(), [conn])
+
+    timeout = psycopg2.errors.QueryCanceled(
+        "canceling statement due to statement timeout"
+    )
+
+    def op(c):
+        raise timeout
+
+    try:
+        mgr._run_read(op)
+        assert False, "expected the query error to surface"
+    except psycopg2.errors.QueryCanceled:
+        pass
+
+    assert mgr.get_connection.call_count == 1  # no retry
+    mgr._pool.putconn.assert_not_called()  # conn not discarded
+    mgr._release.assert_called_once_with(conn)  # released normally
+
+
+def test_run_read_detects_drop_by_closed_flag_without_message_match():
+    """Detection must not depend on the error wording: conn.closed != 0 alone
+    proves the socket is gone."""
+    dead = _make_conn()
+    healthy = _make_conn()
+    mgr = _wire_connections(_bare_manager(), [dead, healthy])
+
+    def op(conn):
+        if conn is dead:
+            conn.closed = 1
+            raise psycopg2.OperationalError("some unfamiliar libpq wording")
+        return "ok"
+
+    assert mgr._run_read(op) == "ok"
+    mgr._pool.putconn.assert_called_once_with(dead, close=True)
+
+
+def test_run_read_raises_when_every_connection_is_dead():
+    """Mass-drop (Supabase kills all idle sockets): fail fast after one retry."""
+    dead1 = _make_conn()
+    dead2 = _make_conn()
+    mgr = _wire_connections(_bare_manager(), [dead1, dead2])
+
+    def op(conn):
+        conn.closed = 1
+        raise _dropped_error()
+
+    try:
+        mgr._run_read(op)
+        assert False, "expected the dropped-connection error to surface"
+    except psycopg2.OperationalError:
+        pass
+
+    assert mgr.get_connection.call_count == DatabaseManager._MAX_DB_TRIES
+    assert mgr._pool.putconn.call_count == 2  # both discarded
+    mgr._release.assert_not_called()  # nothing healthy to release
+
+
+# ── writes ───────────────────────────────────────────────────────────────
+
+
+def test_run_write_retries_pre_commit_drop_and_commits_on_retry():
+    dead = _make_conn()
+    healthy = _make_conn()
+    mgr = _wire_connections(_bare_manager(), [dead, healthy])
+
+    def op(conn):
+        if conn is dead:
+            conn.closed = 1
+            raise _dropped_error()
+        return "wrote"
+
+    assert mgr._run_write(op) == "wrote"
+    # Only the surviving connection is committed.
+    healthy.commit.assert_called_once()
+    dead.commit.assert_not_called()
+    mgr._pool.putconn.assert_called_once_with(dead, close=True)
+
+
+def test_run_write_does_not_retry_commit_failure():
+    """If commit() itself drops, the server may already have committed -- retrying
+    could double-apply the write, so it must NOT retry."""
+    conn = _make_conn()
+    mgr = _wire_connections(_bare_manager(), [conn])
+    conn.commit.side_effect = _dropped_error()
+
+    def op(c):
+        return "wrote"
+
+    try:
+        mgr._run_write(op)
+        assert False, "expected the commit failure to surface"
+    except psycopg2.OperationalError:
+        pass
+
+    assert mgr.get_connection.call_count == 1  # no retry
+    conn.commit.assert_called_once()
+    mgr._release.assert_called_once_with(conn)
+
+
+def test_run_write_does_not_retry_real_query_error():
+    """A constraint violation must surface immediately, not retry."""
+    conn = _make_conn()
+    mgr = _wire_connections(_bare_manager(), [conn])
+
+    def op(c):
+        raise psycopg2.errors.UniqueViolation("duplicate key")
+
+    try:
+        mgr._run_write(op)
+        assert False, "expected the integrity error to surface"
+    except psycopg2.errors.UniqueViolation:
+        pass
+
+    assert mgr.get_connection.call_count == 1
+    conn.commit.assert_not_called()
+    mgr._pool.putconn.assert_not_called()
+    mgr._release.assert_called_once_with(conn)


### PR DESCRIPTION
Closes #110

## Summary
- Pooled psycopg2 connections silently dropped by Supabase (`SSL connection has been closed unexpectedly`) were surfacing as 500s on `/api/alerts/notifications` and aborting the background alert-evaluation flow. The existing pre-ping reduces but cannot eliminate this: a frequently-polled endpoint reuses a "warm" connection that skips the ping, and there is an unavoidable time-of-check/time-of-use gap where Supabase can drop the socket between ping and query.
- Added `_run_read` / `_run_write` helpers in `database.py` that transparently retry **once** on a fresh connection when the socket was dropped. Reads always retry safely (a read that dies on a dead socket never reached the server). Writes retry **only the pre-commit window** — `commit()` lives outside the retry path, so a committed-but-unacked write can never double-apply. Genuine query errors and statement timeouts (`QueryCanceled`) are deliberately not retried.
- Converted both reported failure paths end-to-end (reads and writes): notifications endpoint (`count_unread_price_alert_notifications`, `list_price_alert_notifications_for_user`, `mark_price_alert_notification_read`) and alert evaluation (`list_active_alerts_for_symbols`, `record_price_alert_trigger`, `upsert_price_cache`).

## Why not auto-wrap every DB method
A blanket retry decorator on all 110 methods would be unsafe for writes (double-apply on a committed-but-unacked statement). The explicit read/write split only retries where no double-effect is possible.

## Test plan
- [x] `tests/test_db_stale_connection.py` (7 tests) — read retry, write pre-commit retry, write commit-failure NOT retried, real query error NOT retried, drop detected via `conn.closed` without message match, mass-drop fails fast, no connection leak. All pass.
- [x] `test_connection_pre_ping.py` + `test_flask_price_alerts.py` still pass (pre-ping and warm-window perf optimization left intact).
- [x] Confirmed the one unrelated failing test (`test_alert_evaluation.py::test_evaluate_fires_when_met`) fails identically on clean `main` — pre-existing, not introduced here.