### PR TITLE
feat: StockPro-styled HTML alert emails

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,6 +25,8 @@ FLASK_SECRET_KEY=generate-a-long-random-string
 # Both must be set to send. ALERT_FROM_SENDER must be a Brevo-verified sender.
 # BREVO_API_KEY=
 # ALERT_FROM_SENDER=alerts@yourdomain.com
+# Base URL used for links in alert emails (default https://stock-pro.org)
+# APP_BASE_URL=https://stock-pro.org
 
 # --- Database (Supabase: Project Settings → Database → Connection string, URI format) ---
 # Use the "Transaction" pooler URL for server apps when possible.

--- a/src/alerts/evaluation.py
+++ b/src/alerts/evaluation.py
@@ -72,11 +72,87 @@ def _send_telegram_alert_if_connected(db, user_id: str, symbol: str, body: str) 
         )
 
 
-def _send_email_alert_if_configured(db, user_id: str, symbol: str, body: str) -> None:
+def _build_alert_email_html(
+    symbol: str, price: float, target: float, direction: str
+) -> str:
+    """Render a StockPro-styled HTML email for a fired price alert.
+
+    Email-safe: table layout, inline styles, explicit dark-theme colors
+    (design tokens from the SPA). No external CSS or web fonts required.
+    """
+    up = (direction or "").lower() == "above"
+    accent = "#22c55e" if up else "#ef4444"  # accent-up / accent-down
+    arrow = "&#9650;" if up else "&#9660;"  # up / down triangle
+    base_url = (os.getenv("APP_BASE_URL") or "https://stock-pro.org").rstrip("/")
+    ticker_url = f"{base_url}/ticker/{symbol}"
+    price_str = _format_money(price)
+    target_str = _format_money(target)
+    body_font = (
+        "-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif"
+    )
+    display_font = "'Nunito'," + body_font
+    return f"""<!DOCTYPE html>
+<html>
+<body style="margin:0;padding:0;background-color:#0c0a09;">
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color:#0c0a09;padding:32px 16px;">
+    <tr>
+      <td align="center">
+        <table role="presentation" width="480" cellpadding="0" cellspacing="0" style="max-width:480px;width:100%;background-color:#1c1917;border:1px solid #292524;border-radius:16px;">
+          <tr>
+            <td style="padding:28px 32px 0 32px;">
+              <div style="font-family:{display_font};font-size:18px;font-weight:800;color:#f5f5f4;letter-spacing:-0.3px;">StockPro</div>
+              <div style="font-family:{body_font};font-size:12px;font-weight:600;color:#a8a29e;text-transform:uppercase;letter-spacing:1px;margin-top:6px;">Price Alert</div>
+            </td>
+          </tr>
+          <tr>
+            <td style="padding:20px 32px 0 32px;">
+              <div style="font-family:{display_font};font-size:30px;font-weight:800;color:#f5f5f4;">{symbol}</div>
+              <div style="font-family:{display_font};font-size:38px;font-weight:800;color:{accent};margin-top:4px;">{arrow}&nbsp;{price_str}</div>
+            </td>
+          </tr>
+          <tr>
+            <td style="padding:12px 32px 0 32px;">
+              <p style="font-family:{body_font};font-size:15px;line-height:22px;color:#d6d3d1;margin:0;">{symbol} is now <strong style="color:#f5f5f4;">{price_str}</strong>, {direction} your target of <strong style="color:#f5f5f4;">{target_str}</strong>.</p>
+            </td>
+          </tr>
+          <tr>
+            <td style="padding:28px 32px 0 32px;">
+              <table role="presentation" cellpadding="0" cellspacing="0">
+                <tr>
+                  <td style="background-color:#f5f5f4;border-radius:9999px;">
+                    <a href="{ticker_url}" style="display:inline-block;padding:12px 28px;font-family:{body_font};font-size:14px;font-weight:700;color:#0c0a09;text-decoration:none;border-radius:9999px;">View {symbol} on StockPro</a>
+                  </td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+          <tr>
+            <td style="padding:28px 32px;">
+              <p style="font-family:{body_font};font-size:12px;line-height:18px;color:#78716c;margin:24px 0 0 0;border-top:1px solid #292524;padding-top:20px;">You're receiving this because you set a price alert on StockPro. This one-time alert has now been turned off.</p>
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>"""
+
+
+def _send_email_alert_if_configured(
+    db,
+    user_id: str,
+    symbol: str,
+    body: str,
+    price: float,
+    target: float,
+    direction: str,
+) -> None:
     """Best-effort email delivery via Brevo for users with an email on file.
 
-    Skips silently if Brevo is not configured or the user has no email.
-    Never logs the email address (it is an AES-encrypted field).
+    Sends a StockPro-styled HTML email with a plain-text fallback. Skips
+    silently if Brevo is not configured or the user has no email. Never logs
+    the email address (it is an AES-encrypted field).
     """
     api_key = (os.getenv("BREVO_API_KEY") or "").strip()
     from_email = (os.getenv("ALERT_FROM_SENDER") or "").strip()
@@ -94,6 +170,9 @@ def _send_email_alert_if_configured(db, user_id: str, symbol: str, body: str) ->
                 "sender": {"email": from_email, "name": "StockPro Alerts"},
                 "to": [{"email": email}],
                 "subject": f"{symbol} price alert",
+                "htmlContent": _build_alert_email_html(
+                    symbol, price, target, direction
+                ),
                 "textContent": body,
             },
             timeout=15,
@@ -167,7 +246,9 @@ def evaluate_alerts_for_symbols(db, symbols: Iterable[str]) -> int:
                 nid, alert["user_id"], alert["alert_id"], sym, body
             )
             _send_telegram_alert_if_connected(db, alert["user_id"], sym, body)
-            _send_email_alert_if_configured(db, alert["user_id"], sym, body)
+            _send_email_alert_if_configured(
+                db, alert["user_id"], sym, body, price, target, direction
+            )
             # One-shot: deactivate alert after successful trigger
             try:
                 db.set_price_alert_active(alert["alert_id"], alert["user_id"], False)

--- a/tests/test_alert_evaluation.py
+++ b/tests/test_alert_evaluation.py
@@ -154,14 +154,31 @@ def test_send_email_alert_if_configured(monkeypatch):
         captured["headers"] = headers
         captured["to"] = json["to"]
         captured["text"] = json["textContent"]
+        captured["html"] = json["htmlContent"]
         return _Resp()
 
     monkeypatch.setattr("requests.post", _fake_post)
-    _send_email_alert_if_configured(db, "u1", "AAPL", "AAPL is now $101")
+    _send_email_alert_if_configured(
+        db, "u1", "AAPL", "AAPL is now $101", 101.0, 100.0, "above"
+    )
     assert captured["url"] == "https://api.brevo.com/v3/smtp/email"
     assert captured["headers"]["api-key"] == "xkeysib-test"
     assert captured["to"] == [{"email": "user@example.com"}]
     assert "AAPL" in captured["text"]
+    # HTML body is branded and carries the ticker + accent color (above -> green).
+    assert "StockPro" in captured["html"]
+    assert "AAPL" in captured["html"]
+    assert "#22c55e" in captured["html"]
+    assert "/ticker/AAPL" in captured["html"]
+
+
+def test_alert_email_html_uses_down_color_for_below():
+    from alerts.evaluation import _build_alert_email_html
+
+    html = _build_alert_email_html("BTC", 90.0, 100.0, "below")
+    assert "#ef4444" in html  # accent-down
+    assert "#22c55e" not in html
+    assert "BTC" in html
 
 
 def test_send_email_alert_skips_when_unconfigured(monkeypatch):
@@ -173,7 +190,7 @@ def test_send_email_alert_skips_when_unconfigured(monkeypatch):
         raise AssertionError("requests.post must not be called when unconfigured")
 
     monkeypatch.setattr("requests.post", _boom)
-    _send_email_alert_if_configured(db, "u1", "AAPL", "body")
+    _send_email_alert_if_configured(db, "u1", "AAPL", "body", 101.0, 100.0, "above")
     db.get_user_by_id.assert_not_called()
 
 
@@ -189,4 +206,4 @@ def test_send_email_alert_swallows_send_failure(monkeypatch):
 
     monkeypatch.setattr("requests.post", _boom)
     # Must not raise.
-    _send_email_alert_if_configured(db, "u1", "AAPL", "body")
+    _send_email_alert_if_configured(db, "u1", "AAPL", "body", 101.0, 100.0, "above")


### PR DESCRIPTION
## Summary
- Alert emails were plain text. They now send a **branded, dark-theme HTML email** matching the StockPro SPA design (surface `#1c1917`, border `#292524`, accent-up `#22c55e` / accent-down `#ef4444`), with the ticker, current price (colored + arrow by direction), the target line, and a pill CTA that deep-links to `/ticker/<symbol>`.
- Plain text is kept as the fallback (`textContent`) for clients that don't render HTML.
- New optional `APP_BASE_URL` env var (default `https://stock-pro.org`) controls the CTA link.

## Implementation
- `_build_alert_email_html()` in `src/alerts/evaluation.py` — email-safe table layout, all inline styles, no external CSS/web fonts.
- `_send_email_alert_if_configured()` now takes `price`/`target`/`direction` and sends both `htmlContent` and `textContent`.

## Test plan
- [x] `python -m pytest tests/test_alert_evaluation.py -k email` — passes; asserts the HTML is branded, carries the ticker, the correct accent color per direction, and the `/ticker/<symbol>` link
- [x] Rendered the template and sent a live email through the real `evaluate_alerts_for_symbols` path (DB faked) — received in inbox, renders correctly

## Notes
- No DB/schema or API-contract change. Builds on the merged #119 work.