### PR TITLE
feat(retention): 24h post-signup activation email (#120)

### DIFF
--- a/scripts/send_activation_emails.py
+++ b/scripts/send_activation_emails.py
@@ -1,0 +1,69 @@
+"""
+Send the 24h post-signup activation email (issue #120).
+
+Run hourly (e.g. via a Railway cron service). Claims eligible users atomically
+(signed up 23-25h ago, no portfolio, not yet emailed), sends each a nudge to add
+their researched ticker to a portfolio, and resets the flag on any send failure
+so the user is retried on the next run (still inside the 23-25h window).
+
+Usage:
+    python scripts/send_activation_emails.py
+
+Requires DATABASE_URL, BREVO_API_KEY, and ALERT_FROM_SENDER in the environment.
+"""
+
+import logging
+import os
+import sys
+
+from dotenv import load_dotenv
+
+# Make src/ importable whether run from the project root or elsewhere.
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "src"))
+
+try:
+    load_dotenv()
+except Exception as e:  # pragma: no cover - .env is optional in prod
+    print(f"Warning: could not load .env file: {e}")
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+logger = logging.getLogger("send_activation_emails")
+
+
+def main() -> int:
+    if not os.getenv("DATABASE_URL"):
+        logger.error("DATABASE_URL not set")
+        return 1
+
+    from database import get_database_manager
+    from email_service import send_activation_email
+
+    db = get_database_manager()
+    candidates = db.claim_activation_email_candidates()
+    logger.info("Activation email: %d candidate(s) claimed", len(candidates))
+
+    sent = 0
+    failed = 0
+    for c in candidates:
+        ok = send_activation_email(
+            email=c["email"],
+            username=c["username"],
+            ticker=c.get("ticker"),
+            language=c.get("language", "en"),
+        )
+        if ok:
+            sent += 1
+        else:
+            failed += 1
+            # Reset so the next run retries this user (still within the window).
+            try:
+                db.reset_activation_email_flag(c["user_id"])
+            except Exception:
+                logger.exception("Failed to reset activation flag for a user")
+
+    logger.info("Activation email: sent=%d failed=%d", sent, failed)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/database.py
+++ b/src/database.py
@@ -321,6 +321,17 @@ class DatabaseManager:
                         END IF;
                     END $$
                 """)
+                # activation_email_sent: one-time 24h post-signup nudge flag (issue #120)
+                cur.execute("""
+                    DO $$ BEGIN
+                        IF NOT EXISTS (
+                            SELECT 1 FROM information_schema.columns
+                            WHERE table_schema = 'public' AND table_name = 'users' AND column_name = 'activation_email_sent'
+                        ) THEN
+                            ALTER TABLE users ADD COLUMN activation_email_sent BOOLEAN DEFAULT FALSE;
+                        END IF;
+                    END $$
+                """)
                 cur.execute(
                     "CREATE INDEX IF NOT EXISTS idx_username  ON users (username)"
                 )
@@ -2102,6 +2113,97 @@ class DatabaseManager:
                 return int(row[0]) if row else 0
         except psycopg2.Error as e:
             raise RuntimeError(f"Failed to count portfolios: {e}")
+        finally:
+            self._release(conn)
+
+    def claim_activation_email_candidates(self) -> List[Dict[str, Any]]:
+        """Atomically select-and-mark users due the 24h activation email (#120).
+
+        Eligible = signed up 23-25h ago, zero portfolios, not yet sent. A single
+        UPDATE ... RETURNING claims the rows, so concurrent runners (multiple
+        gunicorn workers, overlapping cron invocations) never double-send. The
+        caller sends each email and, on failure, calls reset_activation_email_flag
+        so the user retries on the next run (still inside the 23-25h window).
+
+        Returns dicts: user_id, username, email (decrypted), ticker (most recent
+        report ticker or None), language ('en' or 'he').
+        """
+        conn = None
+        try:
+            conn = self.get_connection()
+            with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+                cur.execute(
+                    """
+                    UPDATE users
+                    SET activation_email_sent = TRUE
+                    WHERE user_id IN (
+                        SELECT u.user_id
+                        FROM users u
+                        LEFT JOIN portfolios p ON p.user_id = u.user_id
+                        WHERE u.created_at BETWEEN NOW() - INTERVAL '25 hours'
+                                              AND NOW() - INTERVAL '23 hours'
+                          AND p.portfolio_id IS NULL
+                          AND u.activation_email_sent IS NOT TRUE
+                    )
+                    RETURNING user_id, username, email,
+                              COALESCE(preferences, '{}') AS preferences
+                    """
+                )
+                rows = [dict(r) for r in cur.fetchall()]
+                ticker_by_user: Dict[str, str] = {}
+                if rows:
+                    cur.execute(
+                        """
+                        SELECT DISTINCT ON (user_id) user_id, ticker
+                        FROM reports
+                        WHERE user_id = ANY(%s)
+                        ORDER BY user_id, created_at DESC
+                        """,
+                        ([r["user_id"] for r in rows],),
+                    )
+                    ticker_by_user = {
+                        t["user_id"]: t["ticker"] for t in cur.fetchall()
+                    }
+                conn.commit()
+        except psycopg2.Error as e:
+            if conn:
+                conn.rollback()
+            raise RuntimeError(f"Failed to claim activation email candidates: {e}")
+        finally:
+            self._release(conn)
+
+        results: List[Dict[str, Any]] = []
+        for row in rows:
+            prefs = row.get("preferences") or {}
+            language = (prefs.get("language") or "en").strip().lower()
+            if language not in ("en", "he"):
+                language = "en"
+            results.append(
+                {
+                    "user_id": row["user_id"],
+                    "username": row["username"],
+                    "email": decrypt(row["email"]) if row.get("email") else None,
+                    "ticker": ticker_by_user.get(row["user_id"]),
+                    "language": language,
+                }
+            )
+        return results
+
+    def reset_activation_email_flag(self, user_id: str) -> None:
+        """Clear activation_email_sent so a failed send is retried next run (#120)."""
+        conn = None
+        try:
+            conn = self.get_connection()
+            with conn.cursor() as cur:
+                cur.execute(
+                    "UPDATE users SET activation_email_sent = FALSE WHERE user_id = %s",
+                    (user_id,),
+                )
+                conn.commit()
+        except psycopg2.Error as e:
+            if conn:
+                conn.rollback()
+            raise RuntimeError(f"Failed to reset activation email flag: {e}")
         finally:
             self._release(conn)
 

--- a/src/email_service.py
+++ b/src/email_service.py
@@ -1,0 +1,212 @@
+"""
+Transactional email sending via Brevo.
+
+Currently powers the 24h post-signup activation nudge (issue #120). Reuses the
+same Brevo credentials as the price-alert email (BREVO_API_KEY,
+ALERT_FROM_SENDER). All sends are best-effort: if Brevo is not configured or the
+provider returns an error, the functions log and return False instead of raising,
+so callers never crash on a delivery failure.
+"""
+
+import logging
+import os
+from typing import Optional
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+_BODY_FONT = (
+    "-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif"
+)
+_DISPLAY_FONT = "'Nunito'," + _BODY_FONT
+
+
+def _base_url() -> str:
+    return (os.getenv("APP_BASE_URL") or "https://stock-pro.org").rstrip("/")
+
+
+def _post_brevo_email(
+    to_email: str,
+    subject: str,
+    html_content: str,
+    text_content: str,
+    sender_name: str = "StockPro",
+) -> bool:
+    """POST a single email to Brevo. Returns True on a 2xx/3xx response.
+
+    Silently returns False (logging a warning) if Brevo is not configured or the
+    request fails. Never logs the recipient address (email is an encrypted field).
+    """
+    api_key = (os.getenv("BREVO_API_KEY") or "").strip()
+    from_email = (os.getenv("ALERT_FROM_SENDER") or "").strip()
+    if not api_key or not from_email or not to_email:
+        return False
+    try:
+        resp = requests.post(
+            "https://api.brevo.com/v3/smtp/email",
+            headers={"api-key": api_key, "accept": "application/json"},
+            json={
+                "sender": {"email": from_email, "name": sender_name},
+                "to": [{"email": to_email}],
+                "subject": subject,
+                "htmlContent": html_content,
+                "textContent": text_content,
+            },
+            timeout=15,
+        )
+        if resp.status_code >= 400:
+            logger.warning("Brevo email failed: status=%s", resp.status_code)
+            return False
+        return True
+    except Exception:
+        logger.exception("Brevo email send raised")
+        return False
+
+
+def _activation_copy(username: str, ticker: Optional[str], language: str) -> dict:
+    """Return subject + body strings for the activation email in en or he."""
+    he = (language or "").strip().lower() == "he"
+    base = _base_url()
+    if ticker:
+        cta_url = f"{base}/portfolio?add={ticker}"
+    else:
+        cta_url = f"{base}/portfolio"
+
+    if he:
+        if ticker:
+            subject = f"הדוח שלך על {ticker} שמור - רוצה לעקוב אחריו?"
+            intro = f"הרצת אתמול דוח על {ticker}. הניתוח שמור בחשבון שלך."
+            step = (
+                f"הצעד הבא הוא להוסיף את {ticker} לתיק כדי לעקוב אחרי הרווח וההפסד "
+                f"ולקבל התראות מחיר כשהמניה זזה."
+            )
+            cta = f"הוספת {ticker} לתיק"
+        else:
+            subject = "החשבון שלך ב-StockPro מוכן - הנה הצעד הבא"
+            intro = "החשבון שלך ב-StockPro מוכן לשימוש."
+            step = (
+                "הצעד הבא הוא ליצור תיק כדי לעקוב אחרי המניות שלך "
+                "ולקבל התראות מחיר."
+            )
+            cta = "מעבר לתיק שלי"
+        greeting = f"היי {username},"
+        footer = "הצעד הזה לוקח 30 שניות."
+        signoff = "צוות StockPro"
+    else:
+        if ticker:
+            subject = f"Your {ticker} report is saved - ready to track it?"
+            intro = (
+                f"You ran a report on {ticker} yesterday. The analysis is saved "
+                f"in your account."
+            )
+            step = (
+                f"The next step is to add {ticker} to a portfolio so you can track "
+                f"your P&L and get price alerts when it moves."
+            )
+            cta = f"Add {ticker} to a portfolio"
+        else:
+            subject = "You're set up on StockPro - here's what to do next"
+            intro = "Your StockPro account is ready to go."
+            step = (
+                "The next step is to create a portfolio so you can track your "
+                "holdings and get price alerts."
+            )
+            cta = "Go to my portfolio"
+        greeting = f"Hi {username},"
+        footer = "It takes 30 seconds."
+        signoff = "The StockPro team"
+
+    text_content = (
+        f"{greeting}\n\n{intro}\n\n{step}\n\n{cta}: {cta_url}\n\n{footer}\n\n- {signoff}"
+    )
+    return {
+        "subject": subject,
+        "greeting": greeting,
+        "intro": intro,
+        "step": step,
+        "cta": cta,
+        "cta_url": cta_url,
+        "footer": footer,
+        "signoff": signoff,
+        "text": text_content,
+        "rtl": he,
+    }
+
+
+def _build_activation_email_html(copy: dict) -> str:
+    """Render a StockPro-styled dark-theme HTML email from a copy dict.
+
+    Email-safe: table layout, inline styles, explicit colors (SPA design tokens),
+    no external CSS or web fonts. Mirrors the price-alert email styling.
+    """
+    dir_attr = "rtl" if copy["rtl"] else "ltr"
+    align = "right" if copy["rtl"] else "left"
+    return f"""<!DOCTYPE html>
+<html dir="{dir_attr}">
+<body style="margin:0;padding:0;background-color:#0c0a09;">
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color:#0c0a09;padding:32px 16px;">
+    <tr>
+      <td align="center">
+        <table role="presentation" width="480" cellpadding="0" cellspacing="0" dir="{dir_attr}" style="max-width:480px;width:100%;background-color:#1c1917;border:1px solid #292524;border-radius:16px;">
+          <tr>
+            <td style="padding:28px 32px 0 32px;text-align:{align};">
+              <div style="font-family:{_DISPLAY_FONT};font-size:18px;font-weight:800;color:#f5f5f4;letter-spacing:-0.3px;">StockPro</div>
+            </td>
+          </tr>
+          <tr>
+            <td style="padding:20px 32px 0 32px;text-align:{align};">
+              <p style="font-family:{_BODY_FONT};font-size:16px;line-height:24px;color:#f5f5f4;margin:0;font-weight:700;">{copy['greeting']}</p>
+            </td>
+          </tr>
+          <tr>
+            <td style="padding:12px 32px 0 32px;text-align:{align};">
+              <p style="font-family:{_BODY_FONT};font-size:15px;line-height:22px;color:#d6d3d1;margin:0;">{copy['intro']}</p>
+              <p style="font-family:{_BODY_FONT};font-size:15px;line-height:22px;color:#d6d3d1;margin:16px 0 0 0;">{copy['step']}</p>
+            </td>
+          </tr>
+          <tr>
+            <td style="padding:28px 32px 0 32px;text-align:{align};">
+              <table role="presentation" cellpadding="0" cellspacing="0">
+                <tr>
+                  <td style="background-color:#f5f5f4;border-radius:9999px;">
+                    <a href="{copy['cta_url']}" style="display:inline-block;padding:12px 28px;font-family:{_BODY_FONT};font-size:14px;font-weight:700;color:#0c0a09;text-decoration:none;border-radius:9999px;">{copy['cta']}</a>
+                  </td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+          <tr>
+            <td style="padding:20px 32px 0 32px;text-align:{align};">
+              <p style="font-family:{_BODY_FONT};font-size:14px;line-height:20px;color:#a8a29e;margin:0;">{copy['footer']}</p>
+            </td>
+          </tr>
+          <tr>
+            <td style="padding:24px 32px 28px 32px;text-align:{align};">
+              <p style="font-family:{_BODY_FONT};font-size:13px;line-height:18px;color:#78716c;margin:24px 0 0 0;border-top:1px solid #292524;padding-top:20px;">- {copy['signoff']}</p>
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>"""
+
+
+def send_activation_email(
+    email: str,
+    username: str,
+    ticker: Optional[str],
+    language: str = "en",
+) -> bool:
+    """Send the 24h post-signup activation nudge. Returns True if accepted by Brevo.
+
+    Best-effort: returns False (no raise) if Brevo is unconfigured, the email is
+    missing, or the provider errors, so the caller can retry on the next run.
+    """
+    if not email:
+        return False
+    copy = _activation_copy(username or "there", ticker, language)
+    html = _build_activation_email_html(copy)
+    return _post_brevo_email(email, copy["subject"], html, copy["text"])

--- a/tests/test_activation_email.py
+++ b/tests/test_activation_email.py
@@ -1,0 +1,152 @@
+"""Unit tests for the 24h post-signup activation email (issue #120)."""
+
+import importlib.util
+import os
+from unittest.mock import MagicMock
+
+from email_service import send_activation_email
+
+
+class _Resp:
+    def __init__(self, status_code=201):
+        self.status_code = status_code
+
+
+def _capture_post(captured, status_code=201):
+    def _fake_post(url, headers=None, json=None, timeout=None):
+        captured["url"] = url
+        captured["headers"] = headers
+        captured["to"] = json["to"]
+        captured["subject"] = json["subject"]
+        captured["text"] = json["textContent"]
+        captured["html"] = json["htmlContent"]
+        return _Resp(status_code)
+
+    return _fake_post
+
+
+def test_activation_email_en_with_ticker(monkeypatch):
+    monkeypatch.setenv("BREVO_API_KEY", "xkeysib-test")
+    monkeypatch.setenv("ALERT_FROM_SENDER", "alerts@stockpro.test")
+    monkeypatch.setenv("APP_BASE_URL", "https://stock-pro.org")
+    captured = {}
+    monkeypatch.setattr("requests.post", _capture_post(captured))
+
+    ok = send_activation_email("user@example.com", "Sam", "AAPL", "en")
+
+    assert ok is True
+    assert captured["url"] == "https://api.brevo.com/v3/smtp/email"
+    assert captured["to"] == [{"email": "user@example.com"}]
+    assert "AAPL" in captured["subject"]
+    assert "Sam" in captured["html"]
+    # CTA points at the real add-to-portfolio route from issue #111.
+    assert "https://stock-pro.org/portfolio?add=AAPL" in captured["html"]
+    assert "https://stock-pro.org/portfolio?add=AAPL" in captured["text"]
+    assert "StockPro" in captured["html"]
+
+
+def test_activation_email_he_is_rtl(monkeypatch):
+    monkeypatch.setenv("BREVO_API_KEY", "xkeysib-test")
+    monkeypatch.setenv("ALERT_FROM_SENDER", "alerts@stockpro.test")
+    captured = {}
+    monkeypatch.setattr("requests.post", _capture_post(captured))
+
+    ok = send_activation_email("user@example.com", "Dana", "TSLA", "he")
+
+    assert ok is True
+    assert 'dir="rtl"' in captured["html"]
+    # Hebrew copy carries the ticker and a Hebrew word.
+    assert "TSLA" in captured["subject"]
+    assert "היי" in captured["html"]  # "היי" greeting
+
+
+def test_activation_email_fallback_without_ticker(monkeypatch):
+    monkeypatch.setenv("BREVO_API_KEY", "xkeysib-test")
+    monkeypatch.setenv("ALERT_FROM_SENDER", "alerts@stockpro.test")
+    monkeypatch.setenv("APP_BASE_URL", "https://stock-pro.org")
+    captured = {}
+    monkeypatch.setattr("requests.post", _capture_post(captured))
+
+    ok = send_activation_email("user@example.com", "Sam", None, "en")
+
+    assert ok is True
+    # Fallback subject does not embed a ticker; CTA links to bare /portfolio.
+    assert "set up on StockPro" in captured["subject"]
+    assert "https://stock-pro.org/portfolio" in captured["html"]
+    assert "add=" not in captured["html"]
+
+
+def test_activation_email_unconfigured_is_noop(monkeypatch):
+    monkeypatch.delenv("BREVO_API_KEY", raising=False)
+    monkeypatch.delenv("ALERT_FROM_SENDER", raising=False)
+
+    def _boom(*args, **kwargs):
+        raise AssertionError("requests.post must not be called when unconfigured")
+
+    monkeypatch.setattr("requests.post", _boom)
+    assert send_activation_email("user@example.com", "Sam", "AAPL", "en") is False
+
+
+def test_activation_email_missing_email_is_noop(monkeypatch):
+    monkeypatch.setenv("BREVO_API_KEY", "xkeysib-test")
+    monkeypatch.setenv("ALERT_FROM_SENDER", "alerts@stockpro.test")
+
+    def _boom(*args, **kwargs):
+        raise AssertionError("requests.post must not be called without an email")
+
+    monkeypatch.setattr("requests.post", _boom)
+    assert send_activation_email("", "Sam", "AAPL", "en") is False
+
+
+def test_activation_email_provider_error_returns_false(monkeypatch):
+    monkeypatch.setenv("BREVO_API_KEY", "xkeysib-test")
+    monkeypatch.setenv("ALERT_FROM_SENDER", "alerts@stockpro.test")
+    captured = {}
+    monkeypatch.setattr("requests.post", _capture_post(captured, status_code=500))
+    assert send_activation_email("user@example.com", "Sam", "AAPL", "en") is False
+
+
+def test_activation_email_swallows_exception(monkeypatch):
+    monkeypatch.setenv("BREVO_API_KEY", "xkeysib-test")
+    monkeypatch.setenv("ALERT_FROM_SENDER", "alerts@stockpro.test")
+
+    def _boom(*args, **kwargs):
+        raise RuntimeError("network down")
+
+    monkeypatch.setattr("requests.post", _boom)
+    # Must not raise, returns False.
+    assert send_activation_email("user@example.com", "Sam", "AAPL", "en") is False
+
+
+def _load_script():
+    path = os.path.join(
+        os.path.dirname(__file__), "..", "scripts", "send_activation_emails.py"
+    )
+    spec = importlib.util.spec_from_file_location("send_activation_emails", path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_script_resets_flag_only_on_send_failure(monkeypatch):
+    """The cron script sends each claimed user and resets the flag on failure."""
+    monkeypatch.setenv("DATABASE_URL", "postgres://test")
+    mod = _load_script()
+
+    db = MagicMock()
+    db.claim_activation_email_candidates.return_value = [
+        {"user_id": "u1", "username": "Sam", "email": "a@x.test", "ticker": "AAPL", "language": "en"},
+        {"user_id": "u2", "username": "Dana", "email": "b@x.test", "ticker": "TSLA", "language": "he"},
+    ]
+    monkeypatch.setattr("database.get_database_manager", lambda: db)
+
+    # u1 succeeds, u2 fails.
+    def _fake_send(email, username, ticker, language):
+        return email == "a@x.test"
+
+    monkeypatch.setattr("email_service.send_activation_email", _fake_send)
+
+    rc = mod.main()
+    assert rc == 0
+    # Only the failed user's flag is reset for retry.
+    db.reset_activation_email_flag.assert_called_once_with("u2")


### PR DESCRIPTION
## Summary
- Sends a one-time email ~24h after signup to users who **ran a report but have no portfolio**, nudging them to add their researched ticker to a portfolio.
- Email goes through the existing **Brevo** setup (reuses `BREVO_API_KEY` + `ALERT_FROM_SENDER`), with a StockPro-styled dark HTML template and **English + Hebrew** copy.
- Dedup is enforced in the database with a single atomic `UPDATE ... RETURNING`, so it is safe under `gunicorn -w 4` and overlapping cron runs.

## How it works
- `database.py`: new `activation_email_sent` column (idempotent, in `init_schema`); `claim_activation_email_candidates()` atomically selects-and-marks eligible users (signed up 23-25h ago, zero portfolios, not yet sent) and returns each user's most recent report ticker + language (`preferences->>'language'`); `reset_activation_email_flag()` clears the flag so a failed send retries on the next run (still inside the window).
- `email_service.py` (new): `send_activation_email()`. Best-effort - returns `False` instead of raising if Brevo is unconfigured or errors. CTA links to `/portfolio?add=TICKER` (the real route from #111; the issue's `/portfolios?add=` was wrong).
- `scripts/send_activation_emails.py` (new): hourly entrypoint - claims candidates, sends, resets failures, logs counts.

## Deployment note (one-time, manual)
Production runs `gunicorn -w 4`, and the existing `main()`-based background jobs do **not** run under gunicorn. So this ships as a **standalone script meant to be run hourly by a Railway cron service**:

```
python scripts/send_activation_emails.py
```

Add a Railway **Cron** service with that command and an hourly schedule (e.g. `0 * * * *`), sharing the same env (`DATABASE_URL`, `BREVO_API_KEY`, `ALERT_FROM_SENDER`). Until that cron is configured, nothing fires automatically.

## Test plan
- [x] `python -m pytest tests/test_activation_email.py` - 8 passed
- [x] Changed files compile (`py_compile`)
- [ ] Configure the Railway cron service (manual, see above)
- [ ] Verify a real send in staging (set the three env vars, run the script with a seeded eligible user)

Notes:
- No `users.language` column exists; language is read from `users.preferences->>'language'` ('en'/'he'), defaulting to English.
- Pre-existing, unrelated test failure observed locally: `test_alert_evaluation.py::test_evaluate_fires_when_met` (its `set_price_alert_active.assert_not_called()` is out of sync with current `evaluation.py`) - not touched by this PR.

Closes #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)