### PR TITLE
fix: surface and drop empty Nimble news results instead of silent degradation (#146)

### DIFF
--- a/src/news_service.py
+++ b/src/news_service.py
@@ -74,25 +74,39 @@ def _do_refresh_primary(client) -> None:
         morningstar_results = f_morningstar.result()
         wsj_results = f_wsj.result()
 
-    # Sort each source by image presence before interleaving, so image articles
-    # lead within each source without collapsing all no-image sources to the end.
+    # Map, then drop records with no headline. Nimble agents intermittently
+    # return empty placeholder records (an empty {} normalizes to [{}]); without
+    # this filter those render as blank "ghost" cards in the briefing.
+    # Finally sort by image presence so image articles lead within each source
+    # without collapsing all no-image sources to the end.
     def _sort_by_image(items, publisher):
         mapped = [_map_article(item, publisher) for item in items]
+        mapped = [a for a in mapped if a["title"]]
         mapped.sort(key=lambda a: 0 if a["image"] else 1)
         return mapped
 
     sources = [
-        _sort_by_image(bloomberg_results, "Bloomberg"),
-        _sort_by_image(morningstar_results, "Morningstar"),
-        _sort_by_image(wsj_results, "WSJ"),
+        ("Bloomberg", _sort_by_image(bloomberg_results, "Bloomberg")),
+        ("Morningstar", _sort_by_image(morningstar_results, "Morningstar")),
+        ("WSJ", _sort_by_image(wsj_results, "WSJ")),
     ]
 
+    # Surface degradation: an agent that returns HTTP 200 with empty results is
+    # otherwise silent (nimble_client only logs on exceptions), so a degraded or
+    # empty briefing would have no signal at all.
+    for name, items in sources:
+        if not items:
+            logger.warning("news refresh: source '%s' returned no usable articles", name)
+    if all(not items for _, items in sources):
+        logger.error("news refresh: all news sources returned no usable articles; briefing is empty")
+
     # Round-robin interleave: Bloomberg → Morningstar → WSJ
+    source_lists = [items for _, items in sources]
     indices = [0, 0, 0]
     interleaved = []
     while True:
         added = False
-        for i, items in enumerate(sources):
+        for i, items in enumerate(source_lists):
             if indices[i] < len(items):
                 interleaved.append(items[indices[i]])
                 indices[i] += 1

--- a/tests/test_wsj_integration.py
+++ b/tests/test_wsj_integration.py
@@ -4,6 +4,7 @@ Tests for WSJ Nimble agent integration in news_service.py.
 
 import sys
 import os
+import logging
 from pathlib import Path
 from unittest.mock import patch, MagicMock
 
@@ -130,3 +131,66 @@ class TestRefreshPrimaryWsj:
         assert publishers[0] == "Bloomberg"
         assert publishers[1] == "Morningstar"
         assert publishers[2] == "WSJ"
+
+
+class TestEmptyResultHandling:
+    """Empty/placeholder agent results must be dropped and logged, not silently served."""
+
+    def _make_article(self, title):
+        return {
+            "headline": title,
+            "summary": "Summary",
+            "image_url": "",
+            "article_url": f"https://example.com/{title.replace(' ', '-').lower()}",
+        }
+
+    def test_empty_dict_record_does_not_become_ghost_article(self):
+        """A source returning [{}] (Nimble's empty-result shape) yields no blank card."""
+        mock_client = MagicMock()
+        mock_client.run_agent.side_effect = lambda agent, params: {
+            news_service.BLOOMBERG_AGENT: [{}],  # empty placeholder record
+            news_service.MORNINGSTAR_AGENT: [self._make_article("Morningstar 1")],
+            news_service.WSJ_AGENT: [self._make_article("WSJ 1")],
+        }.get(agent, [])
+
+        import nimble_client as nimble_module
+        with patch.object(nimble_module, 'NimbleClient', return_value=mock_client):
+            news_service._cache["primary"]["fetched_at"] = None
+            news_service._refresh_primary()
+
+        articles = news_service._cache["primary"]["articles"]
+        assert all(a["title"] for a in articles)
+        assert "Bloomberg" not in [a["publisher"] for a in articles]
+
+    def test_empty_source_logs_warning(self, caplog):
+        mock_client = MagicMock()
+        mock_client.run_agent.side_effect = lambda agent, params: {
+            news_service.BLOOMBERG_AGENT: [{}],
+            news_service.MORNINGSTAR_AGENT: [self._make_article("Morningstar 1")],
+            news_service.WSJ_AGENT: [self._make_article("WSJ 1")],
+        }.get(agent, [])
+
+        import nimble_client as nimble_module
+        with patch.object(nimble_module, 'NimbleClient', return_value=mock_client):
+            news_service._cache["primary"]["fetched_at"] = None
+            with caplog.at_level(logging.WARNING):
+                news_service._refresh_primary()
+
+        assert "Bloomberg" in caplog.text
+        assert "no usable articles" in caplog.text
+
+    def test_all_sources_empty_logs_aggregate_error(self, caplog):
+        mock_client = MagicMock()
+        mock_client.run_agent.side_effect = lambda agent, params: []
+
+        import nimble_client as nimble_module
+        with patch.object(nimble_module, 'NimbleClient', return_value=mock_client):
+            news_service._cache["primary"]["fetched_at"] = None
+            with caplog.at_level(logging.ERROR):
+                news_service._refresh_primary()
+
+        assert news_service._cache["primary"]["articles"] == []
+        assert any(
+            r.levelno == logging.ERROR and "all news sources returned no usable articles" in r.message
+            for r in caplog.records
+        )


### PR DESCRIPTION
Closes #146

## Summary
- **Diagnosis corrected:** the three news agent IDs are NOT deprecated. Verified live against Nimble — all three agents exist and return HTTP 200. The Jun 16 401/403/timeout lines were transient. The `raise_for_status()` + HTTP-status logging the issue asks for is already on main (#99).
- **Real bug found:** Bloomberg intermittently (~20% of runs) returns an empty `{}`, which normalized to `[{}]` and rendered as a blank ghost card; and an empty/degraded briefing produced no log signal at all.
- **Fix (scoped to `news_service.py`):** drop mapped articles with no title, and log a warning per empty source plus an error when all sources are empty so degradation is visible in Railway logs.

## Test plan
- [x] `tests/test_wsj_integration.py` — 11 passed (8 existing + 3 new: empty-dict dropped, per-source warning, all-empty aggregate error)
- [x] Full suite: 474 passed; 34 failures are pre-existing local issues (legacy Jinja render tests, unified_warmup fixture drift, network/token-dependent watchlist tests) — none touch news_service
- [x] Verified live against Nimble that agents are alive and the fix targets the real failure mode (empty-200 results)

## Not included (deliberately)
- No agent-ID swap (nothing to swap to; current IDs valid)
- No email/Telegram alerting (logging matches existing pattern; lowest-cost path)
- Shared `run_agent` untouched, so pricing fallback chain and sentiment paths are unaffected