### PR TITLE
fix: drop admin_events writes with null user_id (#145)

### DIFF
--- a/src/database.py
+++ b/src/database.py
@@ -1648,6 +1648,11 @@ class DatabaseManager:
         self, event_type: str, user_id: Optional[str] = None, payload: Optional[Dict] = None
     ) -> None:
         """Write a structured event to admin_events. Fire-and-forget safe."""
+        if not user_id:
+            # Analytics events with no user attribution are useless and corrupt
+            # aggregates grouped by user_id. Drop rather than insert a null row
+            # (issue #145). Callers that legitimately lack a user should not log.
+            return
         conn = None
         try:
             conn = self.get_connection()

--- a/tests/test_admin_log_event.py
+++ b/tests/test_admin_log_event.py
@@ -1,0 +1,51 @@
+"""
+admin_log_event() must refuse to write rows with no user_id (issue #145).
+
+A null user_id produces analytics rows that corrupt any aggregate grouped or
+filtered by user_id (e.g. the cohort return-rate watch). Several call sites can
+hand admin_log_event a None (research_graph.storage_node when run_research gets
+no user, the admin config routes via getattr(request, "admin_user_id", None)),
+so the guard lives in the writer itself to cover all of them.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from database import DatabaseManager
+
+
+def _make_manager():
+    mgr = DatabaseManager.__new__(DatabaseManager)
+    mock_cur = MagicMock()
+    mock_conn = MagicMock()
+    ctx = MagicMock()
+    ctx.__enter__.return_value = mock_cur
+    ctx.__exit__.return_value = None
+    mock_conn.cursor.return_value = ctx
+    return mgr, mock_cur, mock_conn
+
+
+def _run(mgr, mock_conn, user_id):
+    with patch.object(mgr, "get_connection", return_value=mock_conn):
+        with patch.object(mgr, "_release"):
+            mgr.admin_log_event("research_complete", user_id, {"ticker": "AAPL"})
+
+
+@pytest.mark.parametrize("user_id", [None, "", 0])
+def test_null_user_id_writes_nothing(user_id):
+    mgr, mock_cur, mock_conn = _make_manager()
+    _run(mgr, mock_conn, user_id)
+
+    mock_cur.execute.assert_not_called()
+    mock_conn.commit.assert_not_called()
+
+
+def test_real_user_id_writes_event():
+    mgr, mock_cur, mock_conn = _make_manager()
+    _run(mgr, mock_conn, "user-1")
+
+    mock_cur.execute.assert_called_once()
+    sql = mock_cur.execute.call_args[0][0]
+    assert "INSERT INTO admin_events" in sql
+    mock_conn.commit.assert_called_once()


### PR DESCRIPTION
## Summary

- `admin_log_event()` accepted `user_id=None` and inserted it straight into `admin_events`, creating null-user rows that corrupt any aggregate grouped/filtered by `user_id` (the Jun 22 cohort return-rate watch depends on clean data).
- The guard is placed in the writer itself so it covers every caller that can pass `None` — `research_graph.storage_node()` (when `run_research` runs without a user) and the admin config routes (`getattr(request, "admin_user_id", None)`). A falsy `user_id` now returns early instead of writing a corrupt row.

## Why here, not at each call site

There are several call sites that can hand `admin_log_event` a `None`. A single central guard in the writer is the minimal, robust fix and answers the issue's requirement #4 ("does the writer validate `user_id`? — make it validate").

## Test plan

- [x] `tests/test_admin_log_event.py` — null/empty/zero `user_id` writes nothing; a real `user_id` writes the event. Passes.
- [x] Confirmed the 34 unrelated suite failures (legacy Jinja page renders + an alert code/test mismatch) are pre-existing on `main`, not caused by this change.

## Follow-ups (not in this PR)

- One-time DB cleanup of existing null rows: `DELETE FROM admin_events WHERE user_id IS NULL` (Supabase operation).
- Deeper trace of *why* `run_research` is sometimes called without a `user_id`; this guard stops the corruption now.

Closes #145

🤖 Generated with [Claude Code](https://claude.com/claude-code)