### PR TITLE
fix: regenerate Bloomberg news agent for reliable extraction (#146)

### DIFF
--- a/src/news_service.py
+++ b/src/news_service.py
@@ -14,11 +14,15 @@ logger = logging.getLogger(__name__)
 
 CACHE_TTL = 15 * 60  # 15 minutes
 
-BLOOMBERG_AGENT = "bloomberg_search_2026_02_23_a9u4p1tv_1184e640"
+# Bloomberg agent regenerated 2026-06-20: the old query-keyword agent had a
+# ~50% empty-result rate (a network-capture race); the regenerated agent takes a
+# full search URL and is ~90% reliable. See issue #146.
+BLOOMBERG_AGENT = "bloomberg_search_2026_06_20_regen"
 MORNINGSTAR_AGENT = "morningstar_search_2026_02_23_zicq0zdj_02869390"
 WSJ_AGENT = "wsj_article_template_2026_03_02_z7hhhvxe"
 WSJ_PIPELINE = "WSJcomUSBusiness"
 SEARCH_QUERY = "markets stocks economy finance"
+BLOOMBERG_SEARCH_URL = "https://www.bloomberg.com/search?query=" + urllib.parse.quote(SEARCH_QUERY)
 
 _cache = {
     "primary": {"articles": [], "fetched_at": None},
@@ -67,7 +71,7 @@ def _refresh_primary() -> None:
 
 def _do_refresh_primary(client) -> None:
     with ThreadPoolExecutor(max_workers=3) as pool:
-        f_bloomberg = pool.submit(client.run_agent, BLOOMBERG_AGENT, {"query": SEARCH_QUERY})
+        f_bloomberg = pool.submit(client.run_agent, BLOOMBERG_AGENT, {"url": BLOOMBERG_SEARCH_URL})
         f_morningstar = pool.submit(client.run_agent, MORNINGSTAR_AGENT, {"search_term": SEARCH_QUERY})
         f_wsj = pool.submit(client.run_agent, WSJ_AGENT, {"feed_name": WSJ_PIPELINE})
         bloomberg_results = f_bloomberg.result()

--- a/tests/test_wsj_integration.py
+++ b/tests/test_wsj_integration.py
@@ -85,6 +85,21 @@ class TestRefreshPrimaryWsj:
             news_service.WSJ_AGENT, {"feed_name": news_service.WSJ_PIPELINE}
         )
 
+    def test_bloomberg_agent_called_with_search_url(self):
+        """Regenerated Bloomberg agent (issue #146) takes a full search URL, not a query keyword."""
+        mock_client = MagicMock()
+        mock_client.run_agent.side_effect = lambda agent, params: []
+
+        import nimble_client as nimble_module
+        with patch.object(nimble_module, 'NimbleClient', return_value=mock_client):
+            news_service._cache["primary"]["fetched_at"] = None
+            news_service._refresh_primary()
+
+        mock_client.run_agent.assert_any_call(
+            news_service.BLOOMBERG_AGENT, {"url": news_service.BLOOMBERG_SEARCH_URL}
+        )
+        assert news_service.BLOOMBERG_SEARCH_URL.startswith("https://www.bloomberg.com/search?query=")
+
     def test_wsj_articles_appear_in_cache_after_refresh(self):
         bloomberg_items = [self._make_article("Bloomberg 1")]
         morningstar_items = [self._make_article("Morningstar 1")]


### PR DESCRIPTION
Follow-up to #146 (the silent-degradation fix). Fixes the underlying cause of Bloomberg's empty results.

## Root cause
The old Bloomberg agent returned empty ~50% of the time due to a **network-capture race**: it intercepts Bloomberg's internal search XHR (`nemo-next/api/search/`) but had `wait_for_requests_count: 0`, so it sometimes grabbed the page before the search results loaded. Same query flipped between 10 results and empty; all query variants behaved the same — confirming it was the agent, not the query.

## Fix
Regenerated the agent via the Nimble CLI (`nimble agent generate`). Measured reliability side-by-side, 10 runs each:

| Agent | Non-empty | Reliability |
|---|---|---|
| Old (`query`) | 5/10 | ~50% |
| New (`url`) | 9/10 | ~90% |

- Swap `BLOOMBERG_AGENT` to the regenerated agent ID.
- The regenerated agent's input contract changed from a query keyword to a full search URL, so we now pass `{"url": "https://www.bloomberg.com/search?query=..."}`. Output field names are identical, so `run_agent`, `_map_article`, the `/api/news` route, and the SPA are untouched.

## Test plan
- [x] `tests/test_wsj_integration.py` — 12 passed (new test asserts the Bloomberg search-URL contract)
- [x] Verified new agent output flows through the real `run_agent` + `_map_article` path
- [x] Live `get_briefing()`: Bloomberg now contributes 10 articles (total 38: BB 10 + MS 8 + WSJ 20), 0 blank cards

## Note
The new agent is ~90% reliable, not 100% — the residual ~10% empties are still dropped and logged by the #146 change, so they degrade gracefully. A 1x retry could close the gap later if desired.