### PR TITLE
feat: weekly portfolio digest email (#129)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,7 @@ audit-screenshots/
 
 
 data/
+
+# Local scratch: diagnostic scripts and Supabase CLI temp
+outputs/
+supabase/

--- a/scripts/send_weekly_digest.py
+++ b/scripts/send_weekly_digest.py
@@ -1,0 +1,91 @@
+"""
+Send the weekly portfolio digest email (issue #129).
+
+Run Monday morning (e.g. via a Railway cron service, recommended schedule
+`0 13 * * 1` UTC -- about 9am US Eastern). Claims eligible users atomically
+(at least one holding, weekly_summary notification not turned off, not sent in
+the last 6 days), computes each user's week-over-week performance, and emails a
+digest. On a send failure the dedupe flag is cleared so the user is retried on
+the next run.
+
+Usage:
+    python scripts/send_weekly_digest.py
+
+Requires DATABASE_URL, BREVO_API_KEY, and ALERT_FROM_SENDER in the environment.
+"""
+
+import logging
+import os
+import sys
+
+from dotenv import load_dotenv
+
+# Make src/ importable whether run from the project root or elsewhere.
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "src"))
+
+try:
+    load_dotenv()
+except Exception as e:  # pragma: no cover - .env is optional in prod
+    print(f"Warning: could not load .env file: {e}")
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+logger = logging.getLogger("send_weekly_digest")
+
+
+def main() -> int:
+    if not os.getenv("DATABASE_URL"):
+        logger.error("DATABASE_URL not set")
+        return 1
+
+    from database import get_database_manager
+    from email_service import send_weekly_digest_email
+    from portfolio.portfolio_service import get_portfolio_service
+
+    db = get_database_manager()
+    portfolio_service = get_portfolio_service()
+
+    candidates = db.claim_weekly_digest_candidates()
+    logger.info("Weekly digest: %d candidate(s) claimed", len(candidates))
+
+    sent = 0
+    skipped = 0
+    failed = 0
+    for c in candidates:
+        try:
+            data = portfolio_service.get_weekly_performance(c["user_id"])
+        except Exception:
+            logger.exception("Failed to compute weekly performance for a user")
+            data = None
+
+        if not data:
+            # Nothing worth emailing (e.g. holdings sold since the claim). Clear
+            # the flag so the user is reconsidered next week.
+            skipped += 1
+            try:
+                db.reset_weekly_digest_flag(c["user_id"])
+            except Exception:
+                logger.exception("Failed to reset weekly digest flag for a user")
+            continue
+
+        ok = send_weekly_digest_email(
+            email=c["email"],
+            username=c["username"],
+            data=data,
+            language=c.get("language", "en"),
+        )
+        if ok:
+            sent += 1
+        else:
+            failed += 1
+            # Reset so the next run retries this user.
+            try:
+                db.reset_weekly_digest_flag(c["user_id"])
+            except Exception:
+                logger.exception("Failed to reset weekly digest flag for a user")
+
+    logger.info("Weekly digest: sent=%d skipped=%d failed=%d", sent, skipped, failed)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/database.py
+++ b/src/database.py
@@ -332,6 +332,17 @@ class DatabaseManager:
                         END IF;
                     END $$
                 """)
+                # weekly_digest_last_sent: date of last weekly portfolio digest (issue #129)
+                cur.execute("""
+                    DO $$ BEGIN
+                        IF NOT EXISTS (
+                            SELECT 1 FROM information_schema.columns
+                            WHERE table_schema = 'public' AND table_name = 'users' AND column_name = 'weekly_digest_last_sent'
+                        ) THEN
+                            ALTER TABLE users ADD COLUMN weekly_digest_last_sent DATE;
+                        END IF;
+                    END $$
+                """)
                 cur.execute(
                     "CREATE INDEX IF NOT EXISTS idx_username  ON users (username)"
                 )
@@ -2204,6 +2215,92 @@ class DatabaseManager:
             if conn:
                 conn.rollback()
             raise RuntimeError(f"Failed to reset activation email flag: {e}")
+        finally:
+            self._release(conn)
+
+    def claim_weekly_digest_candidates(self) -> List[Dict[str, Any]]:
+        """Atomically select-and-mark users due the weekly portfolio digest (#129).
+
+        Eligible = has at least one holding with a positive quantity, has not
+        turned off the 'weekly_summary' notification preference, and has not been
+        sent a digest in the last 6 days. A single UPDATE ... RETURNING claims the
+        rows by stamping weekly_digest_last_sent = CURRENT_DATE, so overlapping
+        cron invocations never double-send. The caller computes and sends each
+        digest and, on failure, calls reset_weekly_digest_flag so the user is
+        retried on the next run.
+
+        Returns dicts: user_id, username, email (decrypted), language ('en'/'he').
+        """
+        conn = None
+        try:
+            conn = self.get_connection()
+            with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+                cur.execute(
+                    """
+                    UPDATE users
+                    SET weekly_digest_last_sent = CURRENT_DATE
+                    WHERE user_id IN (
+                        SELECT u.user_id
+                        FROM users u
+                        WHERE EXISTS (
+                            SELECT 1 FROM holdings h
+                            JOIN portfolios p ON p.portfolio_id = h.portfolio_id
+                            WHERE p.user_id = u.user_id
+                              AND h.total_quantity > 0
+                        )
+                        AND COALESCE(
+                            u.preferences -> 'notifications' ->> 'weekly_summary',
+                            'true'
+                        ) <> 'false'
+                        AND (
+                            u.weekly_digest_last_sent IS NULL
+                            OR u.weekly_digest_last_sent < CURRENT_DATE - INTERVAL '6 days'
+                        )
+                    )
+                    RETURNING user_id, username, email,
+                              COALESCE(preferences, '{}') AS preferences
+                    """
+                )
+                rows = [dict(r) for r in cur.fetchall()]
+                conn.commit()
+        except psycopg2.Error as e:
+            if conn:
+                conn.rollback()
+            raise RuntimeError(f"Failed to claim weekly digest candidates: {e}")
+        finally:
+            self._release(conn)
+
+        results: List[Dict[str, Any]] = []
+        for row in rows:
+            prefs = row.get("preferences") or {}
+            language = (prefs.get("language") or "en").strip().lower()
+            if language not in ("en", "he"):
+                language = "en"
+            results.append(
+                {
+                    "user_id": row["user_id"],
+                    "username": row["username"],
+                    "email": decrypt(row["email"]) if row.get("email") else None,
+                    "language": language,
+                }
+            )
+        return results
+
+    def reset_weekly_digest_flag(self, user_id: str) -> None:
+        """Clear weekly_digest_last_sent so a failed send is retried next run (#129)."""
+        conn = None
+        try:
+            conn = self.get_connection()
+            with conn.cursor() as cur:
+                cur.execute(
+                    "UPDATE users SET weekly_digest_last_sent = NULL WHERE user_id = %s",
+                    (user_id,),
+                )
+                conn.commit()
+        except psycopg2.Error as e:
+            if conn:
+                conn.rollback()
+            raise RuntimeError(f"Failed to reset weekly digest flag: {e}")
         finally:
             self._release(conn)
 

--- a/src/email_service.py
+++ b/src/email_service.py
@@ -210,3 +210,193 @@ def send_activation_email(
     copy = _activation_copy(username or "there", ticker, language)
     html = _build_activation_email_html(copy)
     return _post_brevo_email(email, copy["subject"], html, copy["text"])
+
+
+_ACCENT_UP = "#22c55e"
+_ACCENT_DOWN = "#ef4444"
+
+
+def _fmt_money(amount) -> str:
+    try:
+        return f"${amount:,.2f}"
+    except Exception:
+        return f"${amount}"
+
+
+def _fmt_pct(pct) -> str:
+    """Signed percent to one decimal, e.g. '+2.3%' / '-1.2%'."""
+    return f"{pct:+.1f}%"
+
+
+def _weekly_digest_copy(username: str, language: str, data: dict) -> dict:
+    """Return subject + body fields for the weekly portfolio digest in en or he."""
+    he = (language or "").strip().lower() == "he"
+    cta_url = f"{_base_url()}/portfolio"
+
+    total_value = data.get("total_value")
+    week_change_pct = data.get("week_change_pct")
+    top_mover = data.get("top_mover") or None
+
+    value_str = _fmt_money(total_value)
+    change_str = _fmt_pct(week_change_pct) if week_change_pct is not None else None
+    change_up = week_change_pct is not None and week_change_pct >= 0
+
+    mover_symbol = top_mover.get("symbol") if top_mover else None
+    mover_pct = top_mover.get("pct") if top_mover else None
+    mover_str = (
+        f"{mover_symbol} {_fmt_pct(mover_pct)}"
+        if mover_symbol is not None and mover_pct is not None
+        else None
+    )
+    mover_up = mover_pct is not None and mover_pct >= 0
+
+    if he:
+        if change_str is not None:
+            direction = "עלה ב-" if change_up else "ירד ב-"
+            subject = f"התיק שלך {direction}{abs(week_change_pct):.1f}% השבוע"
+        else:
+            subject = "הסיכום השבועי של התיק שלך"
+        greeting = f"היי {username},"
+        value_label = "שווי התיק"
+        change_label = "השבוע"
+        mover_label = "המניה הבולטת"
+        cta = "צפייה בתיק המלא"
+        footer = "אפשר לבטל את הסיכום השבועי בכל עת בהגדרות."
+        signoff = "צוות StockPro"
+    else:
+        if change_str is not None:
+            direction = "up" if change_up else "down"
+            subject = f"Your portfolio is {direction} {abs(week_change_pct):.1f}% this week"
+        else:
+            subject = "Your weekly portfolio update"
+        greeting = f"Hi {username},"
+        value_label = "Portfolio value"
+        change_label = "This week"
+        mover_label = "Top mover"
+        cta = "View full portfolio"
+        footer = "You can turn off weekly summaries anytime in Settings."
+        signoff = "The StockPro team"
+
+    text_lines = [greeting, "", f"{value_label}: {value_str}"]
+    if change_str is not None:
+        text_lines.append(f"{change_label}: {change_str}")
+    if mover_str is not None:
+        text_lines.append(f"{mover_label}: {mover_str}")
+    text_lines += ["", f"{cta}: {cta_url}", "", footer, "", f"- {signoff}"]
+
+    return {
+        "subject": subject,
+        "greeting": greeting,
+        "value_label": value_label,
+        "value_str": value_str,
+        "change_label": change_label,
+        "change_str": change_str,
+        "change_up": change_up,
+        "mover_label": mover_label,
+        "mover_str": mover_str,
+        "mover_up": mover_up,
+        "cta": cta,
+        "cta_url": cta_url,
+        "footer": footer,
+        "signoff": signoff,
+        "text": "\n".join(text_lines),
+        "rtl": he,
+    }
+
+
+def _build_weekly_digest_email_html(copy: dict) -> str:
+    """Render a StockPro-styled dark-theme HTML digest from a copy dict.
+
+    Email-safe: table layout, inline styles, explicit colors (SPA design tokens),
+    no external CSS or web fonts. Mirrors the activation email styling.
+    """
+    dir_attr = "rtl" if copy["rtl"] else "ltr"
+    align = "right" if copy["rtl"] else "left"
+
+    stat_rows = (
+        f'<p style="font-family:{_BODY_FONT};font-size:13px;line-height:18px;'
+        f'color:#a8a29e;margin:0;">{copy["value_label"]}</p>'
+        f'<p style="font-family:{_DISPLAY_FONT};font-size:30px;line-height:36px;'
+        f'font-weight:800;color:#f5f5f4;margin:4px 0 0 0;">{copy["value_str"]}</p>'
+    )
+    if copy["change_str"] is not None:
+        change_color = _ACCENT_UP if copy["change_up"] else _ACCENT_DOWN
+        stat_rows += (
+            f'<p style="font-family:{_BODY_FONT};font-size:15px;line-height:22px;'
+            f'color:#d6d3d1;margin:16px 0 0 0;">{copy["change_label"]}: '
+            f'<span style="color:{change_color};font-weight:700;">{copy["change_str"]}</span></p>'
+        )
+    if copy["mover_str"] is not None:
+        mover_color = _ACCENT_UP if copy["mover_up"] else _ACCENT_DOWN
+        stat_rows += (
+            f'<p style="font-family:{_BODY_FONT};font-size:15px;line-height:22px;'
+            f'color:#d6d3d1;margin:6px 0 0 0;">{copy["mover_label"]}: '
+            f'<span style="color:{mover_color};font-weight:700;">{copy["mover_str"]}</span></p>'
+        )
+
+    return f"""<!DOCTYPE html>
+<html dir="{dir_attr}">
+<body style="margin:0;padding:0;background-color:#0c0a09;">
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color:#0c0a09;padding:32px 16px;">
+    <tr>
+      <td align="center">
+        <table role="presentation" width="480" cellpadding="0" cellspacing="0" dir="{dir_attr}" style="max-width:480px;width:100%;background-color:#1c1917;border:1px solid #292524;border-radius:16px;">
+          <tr>
+            <td style="padding:28px 32px 0 32px;text-align:{align};">
+              <div style="font-family:{_DISPLAY_FONT};font-size:18px;font-weight:800;color:#f5f5f4;letter-spacing:-0.3px;">StockPro</div>
+            </td>
+          </tr>
+          <tr>
+            <td style="padding:20px 32px 0 32px;text-align:{align};">
+              <p style="font-family:{_BODY_FONT};font-size:16px;line-height:24px;color:#f5f5f4;margin:0;font-weight:700;">{copy['greeting']}</p>
+            </td>
+          </tr>
+          <tr>
+            <td style="padding:16px 32px 0 32px;text-align:{align};">
+              {stat_rows}
+            </td>
+          </tr>
+          <tr>
+            <td style="padding:28px 32px 0 32px;text-align:{align};">
+              <table role="presentation" cellpadding="0" cellspacing="0">
+                <tr>
+                  <td style="background-color:#f5f5f4;border-radius:9999px;">
+                    <a href="{copy['cta_url']}" style="display:inline-block;padding:12px 28px;font-family:{_BODY_FONT};font-size:14px;font-weight:700;color:#0c0a09;text-decoration:none;border-radius:9999px;">{copy['cta']}</a>
+                  </td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+          <tr>
+            <td style="padding:24px 32px 28px 32px;text-align:{align};">
+              <p style="font-family:{_BODY_FONT};font-size:13px;line-height:18px;color:#78716c;margin:24px 0 0 0;border-top:1px solid #292524;padding-top:20px;">{copy['footer']}</p>
+              <p style="font-family:{_BODY_FONT};font-size:13px;line-height:18px;color:#78716c;margin:8px 0 0 0;">- {copy['signoff']}</p>
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>"""
+
+
+def send_weekly_digest_email(
+    email: str,
+    username: str,
+    data: dict,
+    language: str = "en",
+) -> bool:
+    """Send the weekly portfolio digest. Returns True if accepted by Brevo.
+
+    `data` is the dict returned by PortfolioService.get_weekly_performance:
+    total_value, week_change_pct (or None), top_mover (or None), holdings_count.
+
+    Best-effort: returns False (no raise) if Brevo is unconfigured, the email or
+    data is missing, or the provider errors, so the caller can retry next run.
+    """
+    if not email or not data:
+        return False
+    copy = _weekly_digest_copy(username or "there", language, data)
+    html = _build_weekly_digest_email_html(copy)
+    return _post_brevo_email(email, copy["subject"], html, copy["text"])

--- a/src/portfolio/portfolio_service.py
+++ b/src/portfolio/portfolio_service.py
@@ -857,6 +857,144 @@ class PortfolioService:
 
         return {"prices_loaded": True, "sector": sector, "market": market}
 
+    def get_weekly_performance(self, user_id: str) -> Optional[Dict]:
+        """Aggregate a user's weekly portfolio performance for the digest email (#129).
+
+        Compares each holding's current price against its price ~7 days ago (live
+        recompute, no stored snapshots) and rolls the holdings up across all of
+        the user's portfolios. Holdings with no week-ago price (e.g. bought in the
+        last week) count toward the total value but not the week-over-week change.
+
+        Returns None when there is nothing worth emailing (no priced holdings or
+        zero total value). Otherwise a dict:
+            - total_value: Decimal  -- current total market value, USD
+            - week_change_pct: Decimal | None  -- week-over-week %, None if no baseline
+            - top_mover: {"symbol": str, "pct": Decimal} | None  -- largest |weekly move|
+            - holdings_count: int
+        """
+        from currency_utils import convert_to_usd
+
+        portfolios = self.list_portfolios(user_id=user_id)
+        holdings: List[Dict] = []
+        for p in portfolios:
+            holdings.extend(self.get_holdings(p["portfolio_id"], with_prices=True))
+        holdings = [h for h in holdings if h.get("price_available")]
+        if not holdings:
+            return None
+
+        week_ago = self._fetch_week_ago_prices(holdings)
+
+        total_value = Decimal("0")
+        comparable_current = Decimal("0")
+        comparable_prev = Decimal("0")
+        top_symbol: Optional[str] = None
+        top_pct: Optional[Decimal] = None
+
+        for h in holdings:
+            symbol = h["symbol"]
+            qty = Decimal(str(h.get("total_quantity") or 0))
+            cur_price = Decimal(str(h.get("current_price") or 0))
+            currency = h.get("currency") or "USD"
+            cur_value = convert_to_usd(qty * cur_price, currency)
+            total_value += cur_value
+
+            prev_price = week_ago.get(symbol)
+            if prev_price is None or cur_price <= 0:
+                continue
+            prev_price = Decimal(str(prev_price))
+            if prev_price <= 0:
+                continue
+
+            comparable_current += cur_value
+            comparable_prev += convert_to_usd(qty * prev_price, currency)
+
+            pct = (cur_price - prev_price) / prev_price * Decimal("100")
+            if top_pct is None or abs(pct) > abs(top_pct):
+                top_pct = pct
+                top_symbol = symbol
+
+        if total_value <= 0:
+            return None
+
+        week_change_pct = None
+        if comparable_prev > 0:
+            week_change_pct = (
+                (comparable_current - comparable_prev) / comparable_prev * Decimal("100")
+            )
+
+        top_mover = (
+            {"symbol": top_symbol, "pct": top_pct} if top_symbol is not None else None
+        )
+        return {
+            "total_value": total_value,
+            "week_change_pct": week_change_pct,
+            "top_mover": top_mover,
+            "holdings_count": len(holdings),
+        }
+
+    def _fetch_week_ago_prices(self, holdings: List[Dict]) -> Dict[str, Decimal]:
+        """Best-effort price per symbol ~7 days ago, in the symbol's native currency.
+
+        Stocks: yfinance daily closes. Crypto: CoinGecko daily history (reused
+        from the history service). Symbols with no available history are omitted,
+        so the caller treats them as having no week-over-week baseline.
+        """
+        from datetime import date
+
+        target = date.today() - timedelta(days=7)
+        prices: Dict[str, Decimal] = {}
+        stock_syms = {h["symbol"] for h in holdings if h.get("asset_type") == "stock"}
+        crypto_syms = {h["symbol"] for h in holdings if h.get("asset_type") == "crypto"}
+
+        for sym in stock_syms:
+            try:
+                import yfinance as yf
+
+                hist = yf.Ticker(sym).history(
+                    period="14d", interval="1d", auto_adjust=True
+                )
+                if hist.empty:
+                    continue
+                closes = {idx.date(): float(row["Close"]) for idx, row in hist.iterrows()}
+                price = _closest_on_or_before(closes, target)
+                if price is not None:
+                    prices[sym] = Decimal(str(price))
+            except Exception:
+                continue
+
+        if crypto_syms:
+            try:
+                from portfolio.history_service import get_history_service
+
+                hs = get_history_service()
+            except Exception:
+                hs = None
+            for sym in crypto_syms:
+                if hs is None:
+                    break
+                try:
+                    daily = hs._get_crypto_prices(sym)  # {YYYY-MM-DD: price}
+                    if not daily:
+                        continue
+                    closes = {date.fromisoformat(d): p for d, p in daily.items()}
+                    price = _closest_on_or_before(closes, target)
+                    if price is not None:
+                        prices[sym] = Decimal(str(price))
+                except Exception:
+                    continue
+
+        return prices
+
+
+def _closest_on_or_before(prices_by_date: Dict, target) -> Optional[float]:
+    """Return the price on the latest date <= target, or the earliest if none qualify."""
+    if not prices_by_date:
+        return None
+    on_or_before = [d for d in prices_by_date if d <= target]
+    if on_or_before:
+        return prices_by_date[max(on_or_before)]
+    return prices_by_date[min(prices_by_date)]
+
 
 # Global service instance
 _portfolio_service: Optional[PortfolioService] = None

--- a/tests/test_weekly_digest.py
+++ b/tests/test_weekly_digest.py
@@ -1,0 +1,275 @@
+"""Unit tests for the weekly portfolio digest email (issue #129)."""
+
+import importlib.util
+import os
+from datetime import date
+from decimal import Decimal
+from unittest.mock import MagicMock
+
+from email_service import send_weekly_digest_email
+
+
+class _Resp:
+    def __init__(self, status_code=201):
+        self.status_code = status_code
+
+
+def _capture_post(captured, status_code=201):
+    def _fake_post(url, headers=None, json=None, timeout=None):
+        captured["url"] = url
+        captured["to"] = json["to"]
+        captured["subject"] = json["subject"]
+        captured["text"] = json["textContent"]
+        captured["html"] = json["htmlContent"]
+        return _Resp(status_code)
+
+    return _fake_post
+
+
+# --------------------------------------------------------------------------- #
+# Email copy + rendering
+# --------------------------------------------------------------------------- #
+
+def _full_data():
+    return {
+        "total_value": Decimal("12345.67"),
+        "week_change_pct": Decimal("2.3"),
+        "top_mover": {"symbol": "AAPL", "pct": Decimal("5.1")},
+        "holdings_count": 3,
+    }
+
+
+def test_digest_en_up_week(monkeypatch):
+    monkeypatch.setenv("BREVO_API_KEY", "xkeysib-test")
+    monkeypatch.setenv("ALERT_FROM_SENDER", "alerts@stockpro.test")
+    monkeypatch.setenv("APP_BASE_URL", "https://stock-pro.org")
+    captured = {}
+    monkeypatch.setattr("requests.post", _capture_post(captured))
+
+    ok = send_weekly_digest_email("user@example.com", "Sam", _full_data(), "en")
+
+    assert ok is True
+    assert captured["to"] == [{"email": "user@example.com"}]
+    assert "up 2.3%" in captured["subject"]
+    assert "Sam" in captured["html"]
+    assert "$12,345.67" in captured["html"]
+    assert "+2.3%" in captured["html"]
+    assert "AAPL +5.1%" in captured["html"]
+    # Positive change uses the green accent token.
+    assert "#22c55e" in captured["html"]
+    assert "https://stock-pro.org/portfolio" in captured["html"]
+    assert "https://stock-pro.org/portfolio" in captured["text"]
+
+
+def test_digest_en_down_week_uses_red(monkeypatch):
+    monkeypatch.setenv("BREVO_API_KEY", "xkeysib-test")
+    monkeypatch.setenv("ALERT_FROM_SENDER", "alerts@stockpro.test")
+    captured = {}
+    monkeypatch.setattr("requests.post", _capture_post(captured))
+
+    data = _full_data()
+    data["week_change_pct"] = Decimal("-1.2")
+    data["top_mover"] = {"symbol": "TSLA", "pct": Decimal("-4.0")}
+    ok = send_weekly_digest_email("user@example.com", "Sam", data, "en")
+
+    assert ok is True
+    assert "down 1.2%" in captured["subject"]
+    assert "-1.2%" in captured["html"]
+    assert "#ef4444" in captured["html"]
+
+
+def test_digest_he_is_rtl(monkeypatch):
+    monkeypatch.setenv("BREVO_API_KEY", "xkeysib-test")
+    monkeypatch.setenv("ALERT_FROM_SENDER", "alerts@stockpro.test")
+    captured = {}
+    monkeypatch.setattr("requests.post", _capture_post(captured))
+
+    ok = send_weekly_digest_email("user@example.com", "Dana", _full_data(), "he")
+
+    assert ok is True
+    assert 'dir="rtl"' in captured["html"]
+    assert "היי" in captured["html"]  # Hebrew greeting
+    assert "השבוע" in captured["subject"]
+
+
+def test_digest_without_baseline_omits_change(monkeypatch):
+    """A user with no week-ago baseline still gets a value-only digest."""
+    monkeypatch.setenv("BREVO_API_KEY", "xkeysib-test")
+    monkeypatch.setenv("ALERT_FROM_SENDER", "alerts@stockpro.test")
+    captured = {}
+    monkeypatch.setattr("requests.post", _capture_post(captured))
+
+    data = {
+        "total_value": Decimal("500.00"),
+        "week_change_pct": None,
+        "top_mover": None,
+        "holdings_count": 1,
+    }
+    ok = send_weekly_digest_email("user@example.com", "Sam", data, "en")
+
+    assert ok is True
+    assert captured["subject"] == "Your weekly portfolio update"
+    assert "$500.00" in captured["html"]
+    # No change/top-mover rows when there is no baseline.
+    assert "This week" not in captured["html"]
+    assert "Top mover" not in captured["html"]
+
+
+def test_digest_unconfigured_is_noop(monkeypatch):
+    monkeypatch.delenv("BREVO_API_KEY", raising=False)
+    monkeypatch.delenv("ALERT_FROM_SENDER", raising=False)
+
+    def _boom(*args, **kwargs):
+        raise AssertionError("requests.post must not be called when unconfigured")
+
+    monkeypatch.setattr("requests.post", _boom)
+    assert send_weekly_digest_email("user@example.com", "Sam", _full_data(), "en") is False
+
+
+def test_digest_missing_email_or_data_is_noop(monkeypatch):
+    monkeypatch.setenv("BREVO_API_KEY", "xkeysib-test")
+    monkeypatch.setenv("ALERT_FROM_SENDER", "alerts@stockpro.test")
+
+    def _boom(*args, **kwargs):
+        raise AssertionError("requests.post must not be called")
+
+    monkeypatch.setattr("requests.post", _boom)
+    assert send_weekly_digest_email("", "Sam", _full_data(), "en") is False
+    assert send_weekly_digest_email("user@example.com", "Sam", {}, "en") is False
+
+
+def test_digest_provider_error_returns_false(monkeypatch):
+    monkeypatch.setenv("BREVO_API_KEY", "xkeysib-test")
+    monkeypatch.setenv("ALERT_FROM_SENDER", "alerts@stockpro.test")
+    captured = {}
+    monkeypatch.setattr("requests.post", _capture_post(captured, status_code=500))
+    assert send_weekly_digest_email("user@example.com", "Sam", _full_data(), "en") is False
+
+
+# --------------------------------------------------------------------------- #
+# Performance computation
+# --------------------------------------------------------------------------- #
+
+def _make_service(monkeypatch, holdings, week_ago):
+    from portfolio.portfolio_service import PortfolioService
+
+    svc = PortfolioService()
+    monkeypatch.setattr(svc, "list_portfolios", lambda user_id=None: [{"portfolio_id": "p1"}])
+    monkeypatch.setattr(svc, "get_holdings", lambda pid, with_prices=True: holdings)
+    monkeypatch.setattr(svc, "_fetch_week_ago_prices", lambda h: week_ago)
+    return svc
+
+
+def test_weekly_performance_math(monkeypatch):
+    holdings = [
+        {"symbol": "AAPL", "asset_type": "stock", "currency": "USD",
+         "total_quantity": Decimal("10"), "current_price": Decimal("110"), "price_available": True},
+        {"symbol": "MSFT", "asset_type": "stock", "currency": "USD",
+         "total_quantity": Decimal("5"), "current_price": Decimal("200"), "price_available": True},
+    ]
+    week_ago = {"AAPL": Decimal("100"), "MSFT": Decimal("210")}
+    svc = _make_service(monkeypatch, holdings, week_ago)
+
+    result = svc.get_weekly_performance("u1")
+
+    assert result["total_value"] == Decimal("2100")  # 10*110 + 5*200
+    # (2100 - 2050) / 2050 * 100
+    assert round(float(result["week_change_pct"]), 2) == 2.44
+    # AAPL +10% beats MSFT -4.76% on absolute move.
+    assert result["top_mover"]["symbol"] == "AAPL"
+    assert round(float(result["top_mover"]["pct"]), 1) == 10.0
+    assert result["holdings_count"] == 2
+
+
+def test_weekly_performance_new_holding_has_no_baseline(monkeypatch):
+    """A holding bought this week (no week-ago price) counts toward value, not change."""
+    holdings = [
+        {"symbol": "AAPL", "asset_type": "stock", "currency": "USD",
+         "total_quantity": Decimal("10"), "current_price": Decimal("110"), "price_available": True},
+        {"symbol": "NEW", "asset_type": "stock", "currency": "USD",
+         "total_quantity": Decimal("1"), "current_price": Decimal("50"), "price_available": True},
+    ]
+    week_ago = {"AAPL": Decimal("100")}  # NEW has no baseline
+    svc = _make_service(monkeypatch, holdings, week_ago)
+
+    result = svc.get_weekly_performance("u1")
+
+    assert result["total_value"] == Decimal("1150")  # includes NEW
+    # Change computed only from AAPL: (1100-1000)/1000 = +10%
+    assert round(float(result["week_change_pct"]), 1) == 10.0
+    assert result["top_mover"]["symbol"] == "AAPL"
+
+
+def test_weekly_performance_none_when_no_priced_holdings(monkeypatch):
+    holdings = [
+        {"symbol": "AAPL", "asset_type": "stock", "currency": "USD",
+         "total_quantity": Decimal("10"), "current_price": Decimal("0"), "price_available": False},
+    ]
+    svc = _make_service(monkeypatch, holdings, {})
+    assert svc.get_weekly_performance("u1") is None
+
+
+def test_closest_on_or_before():
+    from portfolio.portfolio_service import _closest_on_or_before
+
+    prices = {
+        date(2026, 6, 10): 1.0,
+        date(2026, 6, 13): 2.0,
+        date(2026, 6, 16): 3.0,
+    }
+    assert _closest_on_or_before(prices, date(2026, 6, 13)) == 2.0
+    assert _closest_on_or_before(prices, date(2026, 6, 14)) == 2.0
+    # Target before all data falls back to the earliest available price.
+    assert _closest_on_or_before(prices, date(2026, 6, 9)) == 1.0
+    assert _closest_on_or_before({}, date(2026, 6, 9)) is None
+
+
+# --------------------------------------------------------------------------- #
+# Cron script orchestration
+# --------------------------------------------------------------------------- #
+
+def _load_script():
+    path = os.path.join(
+        os.path.dirname(__file__), "..", "scripts", "send_weekly_digest.py"
+    )
+    spec = importlib.util.spec_from_file_location("send_weekly_digest", path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_script_resets_flag_on_failure_and_no_data(monkeypatch):
+    """Sends each user; resets the flag on send failure and when there is no data."""
+    monkeypatch.setenv("DATABASE_URL", "postgres://test")
+    mod = _load_script()
+
+    db = MagicMock()
+    db.claim_weekly_digest_candidates.return_value = [
+        {"user_id": "u1", "username": "Sam", "email": "a@x.test", "language": "en"},
+        {"user_id": "u2", "username": "Dana", "email": "b@x.test", "language": "he"},
+        {"user_id": "u3", "username": "Lee", "email": "c@x.test", "language": "en"},
+    ]
+    monkeypatch.setattr("database.get_database_manager", lambda: db)
+
+    perf = {
+        "u1": {"total_value": Decimal("100"), "week_change_pct": Decimal("1"),
+               "top_mover": None, "holdings_count": 1},
+        "u2": {"total_value": Decimal("200"), "week_change_pct": Decimal("2"),
+               "top_mover": None, "holdings_count": 1},
+        "u3": None,  # holdings sold since the claim
+    }
+    svc = MagicMock()
+    svc.get_weekly_performance.side_effect = lambda uid: perf[uid]
+    monkeypatch.setattr("portfolio.portfolio_service.get_portfolio_service", lambda: svc)
+
+    # u1 send succeeds, u2 send fails.
+    def _fake_send(email, username, data, language):
+        return email == "a@x.test"
+
+    monkeypatch.setattr("email_service.send_weekly_digest_email", _fake_send)
+
+    rc = mod.main()
+    assert rc == 0
+    # u2 (send failed) and u3 (no data) get reset; u1 does not.
+    reset_ids = {c.args[0] for c in db.reset_weekly_digest_flag.call_args_list}
+    assert reset_ids == {"u2", "u3"}


### PR DESCRIPTION
## Summary
- Adds a weekly Monday-morning email summarizing each user's portfolio: total value, week-over-week %, and the single biggest mover, with a "View full portfolio" CTA.
- Reuses the existing email/cron plumbing from the activation email (#120): Brevo sender, atomic `UPDATE ... RETURNING` claim to dedupe across cron runs, reset-on-failure for retry.
- Opt-out reuses the existing Settings "Weekly portfolio summary" toggle (`preferences.notifications.weekly_summary`) — no frontend change needed.

## How it works
- `database.py`: new `weekly_digest_last_sent DATE` column (idempotent ALTER) + `claim_weekly_digest_candidates()` (has holdings, not opted out, not sent in last 6 days) + `reset_weekly_digest_flag()`.
- `portfolio_service.get_weekly_performance(user_id)`: live recompute of value now vs ~7 days ago across all the user's portfolios; biggest absolute mover. Holdings bought in the last week count toward value but not the change.
- `email_service.send_weekly_digest_email()`: dark-theme HTML, EN + Hebrew (RTL), green/red accents. Best-effort (returns False, never raises).
- `scripts/send_weekly_digest.py`: cron entrypoint.

## Deployment note
Scheduling lives in the Railway dashboard (same as the activation cron, since background timers do not run under gunicorn). Recommended cron: `0 13 * * 1` UTC (~9am US Eastern, Monday). The `weekly_digest_last_sent` guard makes re-runs safe.

## Test plan
- [x] `pytest tests/test_weekly_digest.py` — 12 pass (copy en/he/no-baseline, no-op paths, performance math + new-holding/no-priced edges, `_closest_on_or_before`, script reset orchestration)
- [x] Related suites green: `test_activation_email.py`, `test_cost_basis.py`, `test_csv_importer.py`, `test_portfolio_history.py`
- [x] Module imports clean
- [ ] Live send verified in prod (requires Railway cron wiring + real Brevo creds) — not exercised locally

Note: 16 unrelated failures in `test_multiple_portfolios.py` (legacy Jinja render) and `test_unified_warmup.py` are documented pre-existing local failures, not regressions.

Closes #129