### PR TITLE
fix: weekly digest week-ago price units (#129)

### DIFF
--- a/src/portfolio/portfolio_service.py
+++ b/src/portfolio/portfolio_service.py
@@ -933,18 +933,43 @@ class PortfolioService:
         }
 
     def _fetch_week_ago_prices(self, holdings: List[Dict]) -> Dict[str, Decimal]:
-        """Best-effort price per symbol ~7 days ago, in the symbol's native currency.
+        """Best-effort price per symbol ~7 days ago, in the SAME units as each
+        holding's current_price.
 
-        Stocks: yfinance daily closes. Crypto: CoinGecko daily history (reused
-        from the history service). Symbols with no available history are omitted,
-        so the caller treats them as having no week-over-week baseline.
+        The weekly move is computed as a ratio (weekago_close / latest_close)
+        from a single price series -- yfinance for stocks, CoinGecko for crypto --
+        and applied to the holding's current price. Deriving a ratio from one
+        source keeps the comparison currency/scale-consistent: TASE (.TA) tickers
+        quote in agorot in yfinance while the app stores shekels, so comparing a
+        raw yfinance close against the app's current price would show a bogus
+        ~100x move. The ratio cancels the unit out. Symbols with no usable series
+        are omitted, so the caller treats them as having no baseline.
         """
+        import math
         from datetime import date
 
         target = date.today() - timedelta(days=7)
+        current_price = {
+            h["symbol"]: h.get("current_price")
+            for h in holdings
+            if h.get("current_price") is not None
+        }
         prices: Dict[str, Decimal] = {}
         stock_syms = {h["symbol"] for h in holdings if h.get("asset_type") == "stock"}
         crypto_syms = {h["symbol"] for h in holdings if h.get("asset_type") == "crypto"}
+
+        def _finite_closes(pairs) -> Dict:
+            # Skip NaN/inf closes (yfinance can return them) so they never reach
+            # the Decimal math, where a NaN comparison would raise InvalidOperation.
+            out = {}
+            for d, p in pairs:
+                try:
+                    p = float(p)
+                except (TypeError, ValueError):
+                    continue
+                if math.isfinite(p):
+                    out[d] = p
+            return out
 
         for sym in stock_syms:
             try:
@@ -955,10 +980,14 @@ class PortfolioService:
                 )
                 if hist.empty:
                     continue
-                closes = {idx.date(): float(row["Close"]) for idx, row in hist.iterrows()}
-                price = _closest_on_or_before(closes, target)
-                if price is not None:
-                    prices[sym] = Decimal(str(price))
+                closes = _finite_closes(
+                    (idx.date(), row["Close"]) for idx, row in hist.iterrows()
+                )
+                wap = _week_ago_price_from_series(
+                    current_price.get(sym), closes, target
+                )
+                if wap is not None:
+                    prices[sym] = wap
             except Exception:
                 continue
 
@@ -976,10 +1005,14 @@ class PortfolioService:
                     daily = hs._get_crypto_prices(sym)  # {YYYY-MM-DD: price}
                     if not daily:
                         continue
-                    closes = {date.fromisoformat(d): p for d, p in daily.items()}
-                    price = _closest_on_or_before(closes, target)
-                    if price is not None:
-                        prices[sym] = Decimal(str(price))
+                    closes = _finite_closes(
+                        (date.fromisoformat(d), p) for d, p in daily.items()
+                    )
+                    wap = _week_ago_price_from_series(
+                        current_price.get(sym), closes, target
+                    )
+                    if wap is not None:
+                        prices[sym] = wap
                 except Exception:
                     continue
 
@@ -994,6 +1027,23 @@ def _closest_on_or_before(prices_by_date: Dict, target) -> Optional[float]:
     if on_or_before:
         return prices_by_date[max(on_or_before)]
     return prices_by_date[min(prices_by_date)]
+
+
+def _week_ago_price_from_series(current_price, prices_by_date: Dict, target) -> Optional[Decimal]:
+    """Week-ago price in current_price's units, via the series' own weekly ratio.
+
+    Scales the holding's current price by (weekago_close / latest_close) from the
+    same series so currency/scale (e.g. TASE agorot vs shekels) cancels out.
+    Returns None when current_price is missing or the series yields no usable ratio.
+    """
+    if current_price is None or not prices_by_date:
+        return None
+    latest = prices_by_date[max(prices_by_date)]
+    weekago = _closest_on_or_before(prices_by_date, target)
+    if not latest or latest <= 0 or weekago is None or weekago <= 0:
+        return None
+    ratio = Decimal(str(weekago)) / Decimal(str(latest))
+    return Decimal(str(current_price)) * ratio
 
 
 # Global service instance

--- a/tests/test_weekly_digest.py
+++ b/tests/test_weekly_digest.py
@@ -224,6 +224,28 @@ def test_closest_on_or_before():
     assert _closest_on_or_before({}, date(2026, 6, 9)) is None
 
 
+def test_week_ago_price_is_currency_consistent():
+    """A TASE series quoted in agorot must not produce a bogus ~100x move
+    against an app current price stored in shekels."""
+    from portfolio.portfolio_service import _week_ago_price_from_series
+
+    # Series in agorot (~100x the shekel current price), +1% over the week.
+    closes = {date(2026, 6, 12): 495.0, date(2026, 6, 19): 500.0}
+    current_price_shekels = Decimal("5.0")
+    wap = _week_ago_price_from_series(current_price_shekels, closes, date(2026, 6, 12))
+
+    # ratio 495/500 = 0.99 -> 5.0 * 0.99 = 4.95 (a sane ~+1% move, not a 100x drop)
+    assert wap is not None
+    assert abs(wap - Decimal("4.95")) < Decimal("0.001")
+
+    # Degenerate inputs yield no baseline.
+    assert _week_ago_price_from_series(Decimal("5.0"), {}, date(2026, 6, 12)) is None
+    assert _week_ago_price_from_series(None, closes, date(2026, 6, 12)) is None
+    assert _week_ago_price_from_series(
+        Decimal("5.0"), {date(2026, 6, 19): 0.0}, date(2026, 6, 12)
+    ) is None
+
+
 # --------------------------------------------------------------------------- #
 # Cron script orchestration
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
Follow-up to #154, caught in a production dry run before any email was sent.

## Problem
An Israeli (`.TA`) holding produced "Your portfolio is down 96.9% this week" with a top mover at -99%. yfinance quotes TASE tickers in **agorot** while the app stores the current price in **shekels** -- comparing a raw yfinance close against the app's current price is a ~100x mismatch.

## Fix
- Compute the weekly move as a **ratio** (`weekago_close / latest_close`) from a single price series and apply it to the holding's current price, so the unit cancels out and the comparison is currency/scale-consistent.
- Skip `NaN`/`inf` closes from yfinance before they reach the `Decimal` math (a `NaN` comparison raises `InvalidOperation` and aborts the user's whole digest).

## Verification
- `pytest tests/test_weekly_digest.py` - 13 pass (adds currency-consistency + degenerate-input cases)
- Prod dry run (no send) before fix: `orjslainas` -96.9%; after fix: +0.1% (top mover HOOD +16%), `ors3` +3.6%. Numbers now realistic.

Relates to #129