### PR TITLE
feat: 7-day report expiry nudge email (#130)

### DIFF
--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -160,6 +160,7 @@ set a cron schedule, so these are created in the Railway dashboard (one-time).
 |--------|---------|----------------|-------|
 | `scripts/send_activation_emails.py` | 24h post-signup activation nudge (users with no portfolio) | `0 * * * *` (hourly) | #120 |
 | `scripts/send_weekly_digest.py` | Weekly portfolio digest (Mon morning) | `0 13 * * 1` (~9am US Eastern, Mon) | #129 |
+| `scripts/send_report_expiry_nudges.py` | 7-day report expiry nudge (regenerate a stale report) | `0 14 * * *` (~9-10am US Eastern, daily) | #130 |
 
 Each script is idempotent and safe to re-run: it atomically claims candidates
 (`UPDATE ... RETURNING`) so overlapping runs never double-send, and clears the
@@ -197,6 +198,16 @@ railway run python scripts/send_weekly_digest.py
 Opt-out: the weekly digest respects the existing Settings "Weekly portfolio
 summary" toggle (`preferences.notifications.weekly_summary`). Users with it off,
 or with no holdings, are never claimed.
+
+The report expiry nudge (`send_report_expiry_nudges.py`) claims reports created
+7-14 days ago that are the newest report for their (user, ticker) pair, skipping
+users who set `preferences.notifications.report_expiry` to `false` (defaults on).
+For safe testing against production, pass `--only-user <user_id>` to restrict the
+run to a single user so no real user can be claimed or emailed:
+
+```bash
+railway run python scripts/send_report_expiry_nudges.py --only-user <user_id>
+```
 
 ---
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -178,7 +178,10 @@ For each script above:
    - **Cron Schedule**: the value from the table above.
 3. **Settings** -> **Variables**: the cron service needs `DATABASE_URL`,
    `BREVO_API_KEY`, `ALERT_FROM_SENDER`, and `APP_BASE_URL` (for the email CTA
-   links). Share them from the web service or set the same values.
+   links). Share them from the web service or set the same values. The report
+   expiry nudge also sends from `ALERTS_FROM_SENDER` (optional, defaults to
+   `alerts@stock-pro.org`) -- this address must be a **verified sender** in Brevo
+   (the `stock-pro.org` domain auth covers it).
 4. Disable the public domain / healthcheck for the service -- it is a one-shot
    job, not a web server. Railway runs the start command on the schedule and the
    container exits when the script returns.

--- a/scripts/send_report_expiry_nudges.py
+++ b/scripts/send_report_expiry_nudges.py
@@ -1,0 +1,90 @@
+"""
+Send the 7-day report expiry nudge email (issue #130).
+
+Run daily (e.g. via a Railway cron service, recommended schedule `0 14 * * *`
+UTC -- about 9-10am US Eastern). Claims eligible reports atomically (created
+7-14 days ago, not yet nudged, newest report for that user+ticker, user has not
+turned off the 'report_expiry' notification preference) and emails each user a
+nudge to regenerate. On a send failure the per-report flag is cleared so the
+report is retried on the next run.
+
+Usage:
+    python scripts/send_report_expiry_nudges.py
+    python scripts/send_report_expiry_nudges.py --only-user <user_id>
+
+Pass --only-user to restrict the run to a single user. This is the SAFE way to
+test against the production database: it guarantees no real user's report can be
+claimed or emailed. The unscoped form (no flag) is what the production cron runs.
+
+Requires DATABASE_URL, BREVO_API_KEY, and ALERT_FROM_SENDER in the environment.
+"""
+
+import argparse
+import logging
+import os
+import sys
+
+from dotenv import load_dotenv
+
+# Make src/ importable whether run from the project root or elsewhere.
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "src"))
+
+try:
+    load_dotenv()
+except Exception as e:  # pragma: no cover - .env is optional in prod
+    print(f"Warning: could not load .env file: {e}")
+
+logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+logger = logging.getLogger("send_report_expiry_nudges")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Send 7-day report expiry nudges (#130)")
+    parser.add_argument(
+        "--only-user",
+        dest="only_user",
+        default=None,
+        help="Restrict the run to a single user_id (safe testing).",
+    )
+    args = parser.parse_args()
+
+    if not os.getenv("DATABASE_URL"):
+        logger.error("DATABASE_URL not set")
+        return 1
+
+    from database import get_database_manager
+    from email_service import send_report_expiry_email
+
+    db = get_database_manager()
+
+    if args.only_user:
+        logger.info("Report expiry: scoped to a single user (test mode)")
+
+    candidates = db.claim_report_expiry_candidates(only_user_id=args.only_user)
+    logger.info("Report expiry: %d report(s) claimed", len(candidates))
+
+    sent = 0
+    failed = 0
+    for c in candidates:
+        ok = send_report_expiry_email(
+            email=c["email"],
+            username=c["username"],
+            ticker=c["ticker"],
+            language=c.get("language", "en"),
+        )
+        if ok:
+            sent += 1
+        else:
+            failed += 1
+            # Reset so the next run retries this report (still inside the window).
+            try:
+                db.reset_report_expiry_flag(c["report_id"])
+            except Exception:
+                logger.exception("Failed to reset report expiry flag for a report")
+
+    logger.info("Report expiry: sent=%d failed=%d", sent, failed)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/database.py
+++ b/src/database.py
@@ -386,6 +386,10 @@ class DatabaseManager:
                 cur.execute(
                     "CREATE INDEX IF NOT EXISTS idx_report_user_id    ON reports (user_id)"
                 )
+                # expiry_nudge_sent: per-report 7-day staleness nudge flag (issue #130)
+                cur.execute(
+                    "ALTER TABLE reports ADD COLUMN IF NOT EXISTS expiry_nudge_sent BOOLEAN DEFAULT FALSE"
+                )
 
                 # Report chunks
                 cur.execute("""
@@ -2301,6 +2305,120 @@ class DatabaseManager:
             if conn:
                 conn.rollback()
             raise RuntimeError(f"Failed to reset weekly digest flag: {e}")
+        finally:
+            self._release(conn)
+
+    def claim_report_expiry_candidates(
+        self, only_user_id: Optional[str] = None
+    ) -> List[Dict[str, Any]]:
+        """Atomically select-and-mark reports due the 7-day expiry nudge (#130).
+
+        Eligible report = created 7-14 days ago, not yet nudged, belongs to a
+        user, is the newest report for that (user, ticker) pair (so superseded
+        reports are skipped), and the user has not turned off the 'report_expiry'
+        notification preference. A single UPDATE ... RETURNING claims the rows by
+        stamping expiry_nudge_sent = TRUE, so overlapping cron invocations never
+        double-send. The 7-14 day window also bounds the backlog on first deploy
+        and gives a failed send several days of retry headroom (the caller calls
+        reset_report_expiry_flag on failure).
+
+        Pass only_user_id to restrict the claim to a single user -- used for safe
+        testing so a live run can never touch real users' reports.
+
+        Returns dicts: report_id, user_id, ticker, username, email (decrypted),
+        language ('en' or 'he').
+        """
+        conn = None
+        try:
+            conn = self.get_connection()
+            with conn.cursor(cursor_factory=psycopg2.extras.RealDictCursor) as cur:
+                user_filter = "AND r.user_id = %s" if only_user_id else ""
+                params = (only_user_id,) if only_user_id else ()
+                cur.execute(
+                    f"""
+                    UPDATE reports
+                    SET expiry_nudge_sent = TRUE
+                    WHERE report_id IN (
+                        SELECT r.report_id
+                        FROM reports r
+                        JOIN users u ON u.user_id = r.user_id
+                        WHERE r.user_id IS NOT NULL
+                          AND r.expiry_nudge_sent IS NOT TRUE
+                          AND r.created_at <= NOW() - INTERVAL '7 days'
+                          AND r.created_at >= NOW() - INTERVAL '14 days'
+                          AND NOT EXISTS (
+                              SELECT 1 FROM reports r2
+                              WHERE r2.user_id = r.user_id
+                                AND r2.ticker = r.ticker
+                                AND r2.created_at > r.created_at
+                          )
+                          AND COALESCE(
+                              u.preferences -> 'notifications' ->> 'report_expiry',
+                              'true'
+                          ) <> 'false'
+                          {user_filter}
+                    )
+                    RETURNING report_id, user_id, ticker
+                    """,
+                    params,
+                )
+                rows = [dict(r) for r in cur.fetchall()]
+                users_by_id: Dict[str, Dict[str, Any]] = {}
+                if rows:
+                    cur.execute(
+                        """
+                        SELECT user_id, username, email,
+                               COALESCE(preferences, '{}') AS preferences
+                        FROM users
+                        WHERE user_id = ANY(%s)
+                        """,
+                        ([r["user_id"] for r in rows],),
+                    )
+                    users_by_id = {u["user_id"]: dict(u) for u in cur.fetchall()}
+                conn.commit()
+        except psycopg2.Error as e:
+            if conn:
+                conn.rollback()
+            raise RuntimeError(f"Failed to claim report expiry candidates: {e}")
+        finally:
+            self._release(conn)
+
+        results: List[Dict[str, Any]] = []
+        for row in rows:
+            user = users_by_id.get(row["user_id"])
+            if not user:
+                continue
+            prefs = user.get("preferences") or {}
+            language = (prefs.get("language") or "en").strip().lower()
+            if language not in ("en", "he"):
+                language = "en"
+            results.append(
+                {
+                    "report_id": row["report_id"],
+                    "user_id": row["user_id"],
+                    "ticker": row["ticker"],
+                    "username": user.get("username"),
+                    "email": decrypt(user["email"]) if user.get("email") else None,
+                    "language": language,
+                }
+            )
+        return results
+
+    def reset_report_expiry_flag(self, report_id: str) -> None:
+        """Clear expiry_nudge_sent so a failed send is retried next run (#130)."""
+        conn = None
+        try:
+            conn = self.get_connection()
+            with conn.cursor() as cur:
+                cur.execute(
+                    "UPDATE reports SET expiry_nudge_sent = FALSE WHERE report_id = %s",
+                    (report_id,),
+                )
+                conn.commit()
+        except psycopg2.Error as e:
+            if conn:
+                conn.rollback()
+            raise RuntimeError(f"Failed to reset report expiry flag: {e}")
         finally:
             self._release(conn)
 

--- a/src/email_service.py
+++ b/src/email_service.py
@@ -26,20 +26,32 @@ def _base_url() -> str:
     return (os.getenv("APP_BASE_URL") or "https://stock-pro.org").rstrip("/")
 
 
+def _alerts_from_sender() -> str:
+    """From-address for alert-style emails (the report expiry nudge).
+
+    Env-overridable; defaults to alerts@stock-pro.org so the nudge sends from the
+    alerts mailbox rather than the personal ALERT_FROM_SENDER (or@stock-pro.org)
+    used by the activation email. Must be a verified sender in Brevo.
+    """
+    return (os.getenv("ALERTS_FROM_SENDER") or "alerts@stock-pro.org").strip()
+
+
 def _post_brevo_email(
     to_email: str,
     subject: str,
     html_content: str,
     text_content: str,
     sender_name: str = "StockPro",
+    from_email: Optional[str] = None,
 ) -> bool:
     """POST a single email to Brevo. Returns True on a 2xx/3xx response.
 
+    `from_email` overrides the default sender address (ALERT_FROM_SENDER env).
     Silently returns False (logging a warning) if Brevo is not configured or the
     request fails. Never logs the recipient address (email is an encrypted field).
     """
     api_key = (os.getenv("BREVO_API_KEY") or "").strip()
-    from_email = (os.getenv("ALERT_FROM_SENDER") or "").strip()
+    from_email = (from_email or os.getenv("ALERT_FROM_SENDER") or "").strip()
     if not api_key or not from_email or not to_email:
         return False
     try:
@@ -281,11 +293,16 @@ def send_report_expiry_email(
         return False
     copy = _report_expiry_copy(username or "there", ticker, language)
     html = _build_activation_email_html(copy)
-    # Send under the "StockPro Alerts" sender name, matching the price-alert
-    # email, so the nudge reads as an alert rather than the default "StockPro"
-    # used by the activation email.
+    # Send as "StockPro Alerts" <alerts@stock-pro.org> so the nudge reads as an
+    # alert, distinct from the activation email's default "StockPro"
+    # <or@stock-pro.org> sender.
     return _post_brevo_email(
-        email, copy["subject"], html, copy["text"], sender_name="StockPro Alerts"
+        email,
+        copy["subject"],
+        html,
+        copy["text"],
+        sender_name="StockPro Alerts",
+        from_email=_alerts_from_sender(),
     )
 
 

--- a/src/email_service.py
+++ b/src/email_service.py
@@ -212,6 +212,78 @@ def send_activation_email(
     return _post_brevo_email(email, copy["subject"], html, copy["text"])
 
 
+def _report_expiry_copy(username: str, ticker: str, language: str) -> dict:
+    """Return subject + body strings for the 7-day report expiry nudge (en/he).
+
+    Same copy-dict shape as _activation_copy so it can render through
+    _build_activation_email_html. The CTA points at the research wizard with the
+    ticker prefilled (/research?ticker=...) so one click regenerates the report.
+    """
+    he = (language or "").strip().lower() == "he"
+    cta_url = f"{_base_url()}/research?ticker={ticker}"
+
+    if he:
+        subject = f"הדוח שלך על {ticker} בן 7 ימים - השוק זז מאז"
+        greeting = f"היי {username},"
+        intro = (
+            f"הדוח שלך ב-StockPro על {ticker} בן 7 ימים. שבוע הוא הרבה זמן בשוק - "
+            f"מחירים, חדשות וסנטימנט יכלו להשתנות מאז."
+        )
+        step = "הרצת דוח חדש לוקחת דקה ונותנת לך ניתוח מעודכן לפעול לפיו."
+        cta = f"הרצת דוח חדש על {ticker}"
+        footer = "השוק זז מהר. תישאר מעודכן."
+        signoff = "צוות StockPro"
+    else:
+        subject = f"Your {ticker} report is 7 days old - markets have moved"
+        greeting = f"Hi {username},"
+        intro = (
+            f"Your StockPro report on {ticker} is now 7 days old. A week is a long "
+            f"time in the market - prices, news, and sentiment may have shifted "
+            f"since then."
+        )
+        step = (
+            "Running a fresh report takes about a minute and gives you up-to-date "
+            "analysis to act on."
+        )
+        cta = f"Generate a fresh {ticker} report"
+        footer = "Markets move fast. Stay current."
+        signoff = "The StockPro team"
+
+    text_content = (
+        f"{greeting}\n\n{intro}\n\n{step}\n\n{cta}: {cta_url}\n\n{footer}\n\n- {signoff}"
+    )
+    return {
+        "subject": subject,
+        "greeting": greeting,
+        "intro": intro,
+        "step": step,
+        "cta": cta,
+        "cta_url": cta_url,
+        "footer": footer,
+        "signoff": signoff,
+        "text": text_content,
+        "rtl": he,
+    }
+
+
+def send_report_expiry_email(
+    email: str,
+    username: str,
+    ticker: str,
+    language: str = "en",
+) -> bool:
+    """Send the 7-day report expiry nudge. Returns True if accepted by Brevo.
+
+    Best-effort: returns False (no raise) if Brevo is unconfigured, the email or
+    ticker is missing, or the provider errors, so the caller can retry next run.
+    """
+    if not email or not ticker:
+        return False
+    copy = _report_expiry_copy(username or "there", ticker, language)
+    html = _build_activation_email_html(copy)
+    return _post_brevo_email(email, copy["subject"], html, copy["text"])
+
+
 _ACCENT_UP = "#22c55e"
 _ACCENT_DOWN = "#ef4444"
 

--- a/src/email_service.py
+++ b/src/email_service.py
@@ -281,7 +281,12 @@ def send_report_expiry_email(
         return False
     copy = _report_expiry_copy(username or "there", ticker, language)
     html = _build_activation_email_html(copy)
-    return _post_brevo_email(email, copy["subject"], html, copy["text"])
+    # Send under the "StockPro Alerts" sender name, matching the price-alert
+    # email, so the nudge reads as an alert rather than the default "StockPro"
+    # used by the activation email.
+    return _post_brevo_email(
+        email, copy["subject"], html, copy["text"], sender_name="StockPro Alerts"
+    )
 
 
 _ACCENT_UP = "#22c55e"

--- a/tests/test_report_expiry.py
+++ b/tests/test_report_expiry.py
@@ -1,0 +1,84 @@
+"""Unit tests for the 7-day report expiry nudge email (issue #130)."""
+
+from email_service import send_report_expiry_email
+
+
+class _Resp:
+    def __init__(self, status_code=201):
+        self.status_code = status_code
+
+
+def _capture_post(captured, status_code=201):
+    def _fake_post(url, headers=None, json=None, timeout=None):
+        captured["url"] = url
+        captured["to"] = json["to"]
+        captured["subject"] = json["subject"]
+        captured["text"] = json["textContent"]
+        captured["html"] = json["htmlContent"]
+        return _Resp(status_code)
+
+    return _fake_post
+
+
+def test_expiry_en(monkeypatch):
+    monkeypatch.setenv("BREVO_API_KEY", "xkeysib-test")
+    monkeypatch.setenv("ALERT_FROM_SENDER", "alerts@stockpro.test")
+    monkeypatch.setenv("APP_BASE_URL", "https://stock-pro.org")
+    captured = {}
+    monkeypatch.setattr("requests.post", _capture_post(captured))
+
+    ok = send_report_expiry_email("user@example.com", "Sam", "NVDA", "en")
+
+    assert ok is True
+    assert captured["to"] == [{"email": "user@example.com"}]
+    assert "NVDA" in captured["subject"]
+    assert "7 days old" in captured["subject"]
+    assert "Sam" in captured["html"]
+    # CTA links to the research wizard with the ticker prefilled.
+    assert "https://stock-pro.org/research?ticker=NVDA" in captured["html"]
+    assert "https://stock-pro.org/research?ticker=NVDA" in captured["text"]
+
+
+def test_expiry_he_is_rtl(monkeypatch):
+    monkeypatch.setenv("BREVO_API_KEY", "xkeysib-test")
+    monkeypatch.setenv("ALERT_FROM_SENDER", "alerts@stockpro.test")
+    captured = {}
+    monkeypatch.setattr("requests.post", _capture_post(captured))
+
+    ok = send_report_expiry_email("user@example.com", "Dana", "AAPL", "he")
+
+    assert ok is True
+    assert 'dir="rtl"' in captured["html"]
+    assert "היי" in captured["html"]  # Hebrew greeting
+    assert "AAPL" in captured["subject"]
+
+
+def test_expiry_unconfigured_is_noop(monkeypatch):
+    monkeypatch.delenv("BREVO_API_KEY", raising=False)
+    monkeypatch.delenv("ALERT_FROM_SENDER", raising=False)
+
+    def _boom(*args, **kwargs):
+        raise AssertionError("requests.post must not be called when unconfigured")
+
+    monkeypatch.setattr("requests.post", _boom)
+    assert send_report_expiry_email("user@example.com", "Sam", "NVDA", "en") is False
+
+
+def test_expiry_missing_email_or_ticker_is_noop(monkeypatch):
+    monkeypatch.setenv("BREVO_API_KEY", "xkeysib-test")
+    monkeypatch.setenv("ALERT_FROM_SENDER", "alerts@stockpro.test")
+
+    def _boom(*args, **kwargs):
+        raise AssertionError("requests.post must not be called")
+
+    monkeypatch.setattr("requests.post", _boom)
+    assert send_report_expiry_email("", "Sam", "NVDA", "en") is False
+    assert send_report_expiry_email("user@example.com", "Sam", "", "en") is False
+
+
+def test_expiry_provider_error_returns_false(monkeypatch):
+    monkeypatch.setenv("BREVO_API_KEY", "xkeysib-test")
+    monkeypatch.setenv("ALERT_FROM_SENDER", "alerts@stockpro.test")
+    captured = {}
+    monkeypatch.setattr("requests.post", _capture_post(captured, status_code=500))
+    assert send_report_expiry_email("user@example.com", "Sam", "NVDA", "en") is False

--- a/tests/test_report_expiry.py
+++ b/tests/test_report_expiry.py
@@ -12,6 +12,7 @@ def _capture_post(captured, status_code=201):
     def _fake_post(url, headers=None, json=None, timeout=None):
         captured["url"] = url
         captured["to"] = json["to"]
+        captured["sender"] = json["sender"]
         captured["subject"] = json["subject"]
         captured["text"] = json["textContent"]
         captured["html"] = json["htmlContent"]
@@ -31,6 +32,8 @@ def test_expiry_en(monkeypatch):
 
     assert ok is True
     assert captured["to"] == [{"email": "user@example.com"}]
+    # Sends under the "StockPro Alerts" sender name (matches the price-alert email).
+    assert captured["sender"]["name"] == "StockPro Alerts"
     assert "NVDA" in captured["subject"]
     assert "7 days old" in captured["subject"]
     assert "Sam" in captured["html"]

--- a/tests/test_report_expiry.py
+++ b/tests/test_report_expiry.py
@@ -32,8 +32,10 @@ def test_expiry_en(monkeypatch):
 
     assert ok is True
     assert captured["to"] == [{"email": "user@example.com"}]
-    # Sends under the "StockPro Alerts" sender name (matches the price-alert email).
+    # Sends as "StockPro Alerts" <alerts@stock-pro.org>, distinct from the
+    # activation email's default "StockPro" <or@stock-pro.org> sender.
     assert captured["sender"]["name"] == "StockPro Alerts"
+    assert captured["sender"]["email"] == "alerts@stock-pro.org"
     assert "NVDA" in captured["subject"]
     assert "7 days old" in captured["subject"]
     assert "Sam" in captured["html"]


### PR DESCRIPTION
Closes #130

## Summary
- Emails a user when one of their reports turns 7 days old, with a CTA to regenerate it (links to the research wizard with the ticker prefilled).
- New per-report dedup flag `reports.expiry_nudge_sent` (idempotent migration). Atomic `claim_report_expiry_candidates()` claims reports created 7-14 days ago that are the newest report for their (user, ticker) pair and whose user hasn't disabled the `report_expiry` notification preference; superseded reports and opted-out users are skipped.
- New daily Railway cron script `scripts/send_report_expiry_nudges.py`. It takes a `--only-user <user_id>` flag that scopes a run to a single user, which is the safe way to test against the production DB (a live run can never claim or email a real user).

Reuses the existing Brevo email service and the same atomic claim/reset pattern as the weekly digest (#129) and activation email (#120). No Settings UI / dist rebuild (backend-only); the opt-out preference defaults on and is respected if set.

## Test plan
- [x] Unit tests (`tests/test_report_expiry.py`): en + he (RTL) rendering, subject contains ticker, CTA URL is `/research?ticker=...`, unconfigured-Brevo no-op, missing email/ticker no-op, provider-error returns False. All pass.
- [x] Existing email tests still pass (`test_weekly_digest.py`, `test_activation_email.py`).
- [x] `database.py` imports cleanly; new methods present.
- [x] Scoped live E2E on the test account only (`--only-user`): inserted one backdated report, ran the script, it claimed the test user's eligible reports and sent. Both emails confirmed delivered to the test inbox. Injected test report cleaned up afterward; no real user was ever in scope.

## Deploy note
The Railway cron service must be created manually in the dashboard (CLI can't set cron). Suggested schedule `0 14 * * *` (daily). See `docs/DEPLOYMENT.md` section 8. The `expiry_nudge_sent` column is added idempotently by `init_schema` on deploy.