### PR TITLE
fix: weekly digest sender -> StockPro Alerts <alerts@stock-pro.org> (#129)

### DIFF
--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -179,9 +179,9 @@ For each script above:
 3. **Settings** -> **Variables**: the cron service needs `DATABASE_URL`,
    `BREVO_API_KEY`, `ALERT_FROM_SENDER`, and `APP_BASE_URL` (for the email CTA
    links). Share them from the web service or set the same values. The report
-   expiry nudge also sends from `ALERTS_FROM_SENDER` (optional, defaults to
-   `alerts@stock-pro.org`) -- this address must be a **verified sender** in Brevo
-   (the `stock-pro.org` domain auth covers it).
+   expiry nudge and the weekly digest send from `ALERTS_FROM_SENDER` (optional,
+   defaults to `alerts@stock-pro.org`) -- this address must be a **verified
+   sender** in Brevo (the `stock-pro.org` domain auth covers it).
 4. Disable the public domain / healthcheck for the service -- it is a one-shot
    job, not a web server. Railway runs the start command on the schedule and the
    container exits when the script returns.

--- a/src/email_service.py
+++ b/src/email_service.py
@@ -493,4 +493,8 @@ def send_weekly_digest_email(
         return False
     copy = _weekly_digest_copy(username or "there", language, data)
     html = _build_weekly_digest_email_html(copy)
-    return _post_brevo_email(email, copy["subject"], html, copy["text"])
+    # Send under the "StockPro Alerts" sender name (matches the price-alert and
+    # report-expiry emails). From-address stays ALERT_FROM_SENDER (or@stock-pro.org).
+    return _post_brevo_email(
+        email, copy["subject"], html, copy["text"], sender_name="StockPro Alerts"
+    )

--- a/src/email_service.py
+++ b/src/email_service.py
@@ -493,8 +493,13 @@ def send_weekly_digest_email(
         return False
     copy = _weekly_digest_copy(username or "there", language, data)
     html = _build_weekly_digest_email_html(copy)
-    # Send under the "StockPro Alerts" sender name (matches the price-alert and
-    # report-expiry emails). From-address stays ALERT_FROM_SENDER (or@stock-pro.org).
+    # Send as "StockPro Alerts" <alerts@stock-pro.org>, matching the report-expiry
+    # email, so both alert-style emails share one identity.
     return _post_brevo_email(
-        email, copy["subject"], html, copy["text"], sender_name="StockPro Alerts"
+        email,
+        copy["subject"],
+        html,
+        copy["text"],
+        sender_name="StockPro Alerts",
+        from_email=_alerts_from_sender(),
     )

--- a/tests/test_weekly_digest.py
+++ b/tests/test_weekly_digest.py
@@ -18,6 +18,7 @@ def _capture_post(captured, status_code=201):
     def _fake_post(url, headers=None, json=None, timeout=None):
         captured["url"] = url
         captured["to"] = json["to"]
+        captured["sender"] = json["sender"]
         captured["subject"] = json["subject"]
         captured["text"] = json["textContent"]
         captured["html"] = json["htmlContent"]
@@ -50,6 +51,7 @@ def test_digest_en_up_week(monkeypatch):
 
     assert ok is True
     assert captured["to"] == [{"email": "user@example.com"}]
+    assert captured["sender"]["name"] == "StockPro Alerts"
     assert "up 2.3%" in captured["subject"]
     assert "Sam" in captured["html"]
     assert "$12,345.67" in captured["html"]

--- a/tests/test_weekly_digest.py
+++ b/tests/test_weekly_digest.py
@@ -52,6 +52,7 @@ def test_digest_en_up_week(monkeypatch):
     assert ok is True
     assert captured["to"] == [{"email": "user@example.com"}]
     assert captured["sender"]["name"] == "StockPro Alerts"
+    assert captured["sender"]["email"] == "alerts@stock-pro.org"
     assert "up 2.3%" in captured["subject"]
     assert "Sam" in captured["html"]
     assert "$12,345.67" in captured["html"]


### PR DESCRIPTION
## Summary
- The weekly portfolio digest email now sends as **"StockPro Alerts" &lt;alerts@stock-pro.org&gt;**, matching the report-expiry (#130) and price-alert emails so all alert-style emails share one sender identity.
- From-address resolves from `ALERTS_FROM_SENDER` (optional, defaults to `alerts@stock-pro.org`).
- The activation email is untouched (keeps "StockPro" &lt;or@stock-pro.org&gt;).

## Test plan
- [x] `tests/test_weekly_digest.py` asserts both the sender name ("StockPro Alerts") and address (alerts@stock-pro.org).
- [x] All email tests pass (27): weekly digest, activation, report expiry.