### PR TITLE
fix: re-prime CLI report agent from generation_status row to survive multi-worker routing (#165)

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -1406,7 +1406,10 @@ def report_status(session_id: str):
         return jsonify({"error": "forbidden"}), 403
 
     # Strip internal/timestamp columns and any None values for a clean response.
-    _hidden = {"user_id", "session_id", "created_at", "updated_at", "expires_at"}
+    _hidden = {
+        "user_id", "session_id", "created_at", "updated_at", "expires_at",
+        "ticker", "trade_type",
+    }
     return jsonify({k: v for k, v in row.items() if k not in _hidden and v is not None})
 
 
@@ -1501,12 +1504,16 @@ def api_reports_generate():
     ]
 
     if not no_questions:
+        # Persist ticker/trade_type so /api/reports/answer can re-prime the
+        # agent when it lands on a different gunicorn worker (issue #165).
         db.set_generation_status(
             session_id,
             user_id,
             status="needs_input",
             questions=pending,
             subjects=subjects,
+            ticker=ticker,
+            trade_type=trade_type,
         )
         return jsonify({
             "success": True,
@@ -1523,6 +1530,8 @@ def api_reports_generate():
         progress=5,
         step="Starting...",
         step_code="starting",
+        ticker=ticker,
+        trade_type=trade_type,
     )
 
     _start_report_generation_thread(session_id, agent, context_str, user_id, spend_budget_usd)
@@ -1671,6 +1680,43 @@ def api_reports_answer():
     context_str = "User context:\n" + "\n".join(lines) if lines else ""
 
     agent = initialize_session(session_id)
+
+    # Re-prime the agent from the generation_status row when this worker's
+    # in-memory agent is fresh. /api/reports/generate primes the agent on
+    # whichever gunicorn worker served it; this request can land on a different
+    # worker whose agent_sessions has no primed agent (issue #165, same class
+    # as #116). CLI callers use Bearer auth with no session cookie, so the DB
+    # row -- shared across workers -- is the only place to recover state from.
+    if not agent.current_ticker:
+        _ct = (row.get("ticker") or "").strip().upper()
+        _tt = (row.get("trade_type") or "").strip()
+        if _ct and _tt:
+            agent.current_ticker = _ct
+            agent.current_trade_type = _tt
+
+    # If the ticker still cannot be recovered, fail loudly instead of running
+    # a blank agent that reports "upstream data sources are down".
+    if not agent.current_ticker or not agent.current_trade_type:
+        return (
+            jsonify({"error": "No active research session. Please restart the report."}),
+            400,
+        )
+
+    if not agent.user_id:
+        agent.user_id = user_id
+    if not agent.username:
+        try:
+            _user_rec = db.get_user_by_id(user_id)
+            agent.username = _user_rec.get("username", user_id) if _user_rec else user_id
+        except Exception:
+            agent.username = user_id
+    try:
+        _user_rec2 = db.get_user_by_id(user_id)
+        agent.language = (
+            (_user_rec2.get("preferences") or {}).get("language", "en") if _user_rec2 else "en"
+        )
+    except Exception:
+        agent.language = "en"
 
     from spend_budget import get_spend_budget_usd
     spend_budget_usd = get_spend_budget_usd(agent.user_id)

--- a/src/database.py
+++ b/src/database.py
@@ -859,6 +859,8 @@ class DatabaseManager:
                         questions       JSONB,
                         subjects        JSONB,
                         failed_subjects JSONB,
+                        ticker          TEXT,
+                        trade_type      TEXT,
                         created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
                         updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
                         expires_at      TIMESTAMPTZ NOT NULL DEFAULT (NOW() + INTERVAL '24 hours')
@@ -870,6 +872,20 @@ class DatabaseManager:
                 cur.execute(
                     "CREATE INDEX IF NOT EXISTS idx_generation_status_expires ON generation_status (expires_at)"
                 )
+                # ticker/trade_type: let /api/reports/answer re-prime a fresh
+                # agent when it lands on a different gunicorn worker than
+                # /api/reports/generate (issue #165, same class as #116)
+                cur.execute("""
+                    DO $$ BEGIN
+                        IF NOT EXISTS (
+                            SELECT 1 FROM information_schema.columns
+                            WHERE table_schema = 'public' AND table_name = 'generation_status' AND column_name = 'ticker'
+                        ) THEN
+                            ALTER TABLE generation_status ADD COLUMN ticker TEXT;
+                            ALTER TABLE generation_status ADD COLUMN trade_type TEXT;
+                        END IF;
+                    END $$
+                """)
 
                 # SSE event queue: replaces the per-process `_sse_queues` dict
                 # so the producer thread on one worker and the SSE consumer on
@@ -3690,6 +3706,8 @@ class DatabaseManager:
         "questions",
         "subjects",
         "failed_subjects",
+        "ticker",
+        "trade_type",
     }
     _GEN_STATUS_JSON_FIELDS = {"questions", "subjects", "failed_subjects"}
 
@@ -3744,7 +3762,8 @@ class DatabaseManager:
                     """
                     SELECT session_id, user_id, status, report_id, progress, step,
                            step_code, done, total, partial, message, questions,
-                           subjects, failed_subjects, created_at, updated_at, expires_at
+                           subjects, failed_subjects, ticker, trade_type,
+                           created_at, updated_at, expires_at
                     FROM generation_status
                     WHERE session_id = %s
                     """,

--- a/tests/test_reports_cli_flow.py
+++ b/tests/test_reports_cli_flow.py
@@ -1,0 +1,185 @@
+"""CLI/headless report flow: /api/reports/generate and /api/reports/answer.
+
+Regression tests for issue #165: generate and answer can land on different
+gunicorn workers, so answer must re-prime a fresh agent from the
+generation_status DB row instead of running a blank agent (which surfaced
+as a fake "upstream data sources are down" error).
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent / "src"))
+
+
+@pytest.fixture
+def api_app():
+    from app import app as flask_app
+
+    flask_app.config["TESTING"] = True
+    flask_app.config["WTF_CSRF_ENABLED"] = False
+    flask_app.config["SECRET_KEY"] = "test-reports-cli-flow"
+    return flask_app
+
+
+@pytest.fixture
+def api_client(api_app):
+    return api_app.test_client()
+
+
+def _needs_input_row(**overrides):
+    row = {
+        "session_id": "sid-cli",
+        "user_id": "u1",
+        "status": "needs_input",
+        "questions": [{"question": "Goal?", "options": ["Long", "Short"]}],
+        "subjects": [],
+        "ticker": "AAPL",
+        "trade_type": "Investment",
+    }
+    row.update(overrides)
+    return row
+
+
+def test_generate_persists_ticker_and_trade_type(api_client):
+    """generate must store ticker/trade_type in the DB row so a different
+    worker can re-prime the agent at answer time (#165)."""
+    import app as app_module
+
+    mock_agent = MagicMock()
+    mock_agent.pending_questions = [{"question": "Goal?", "options": ["Long"]}]
+
+    with patch.object(app_module, "_session_hits_report_quota", return_value=False), \
+         patch.object(app_module, "initialize_session", return_value=mock_agent), \
+         patch.object(app_module.db, "set_generation_status") as set_status, \
+         patch.object(app_module.db, "get_user_by_id", return_value=None), \
+         patch("spend_budget.get_spend_budget_usd", return_value=2.5):
+        with api_client.session_transaction() as sess:
+            sess["user_id"] = "u1"
+            sess["username"] = "u"
+        resp = api_client.post(
+            "/api/reports/generate",
+            json={"ticker": "AAPL", "trade_type": "Investment"},
+        )
+
+    assert resp.status_code == 200
+    kwargs = set_status.call_args.kwargs
+    assert kwargs["status"] == "needs_input"
+    assert kwargs["ticker"] == "AAPL"
+    assert kwargs["trade_type"] == "Investment"
+
+
+def test_answer_reprimes_fresh_agent_from_db_row(api_client):
+    """Cross-worker case (#165): answer lands on a worker whose in-memory agent
+    is blank. It must restore ticker/trade_type from the DB row, set the user
+    identity, and start generation instead of failing."""
+    import app as app_module
+
+    mock_agent = MagicMock()
+    mock_agent.current_ticker = None
+    mock_agent.current_trade_type = None
+    mock_agent.user_id = None
+    mock_agent.username = None
+    mock_thread = MagicMock()
+
+    with patch.object(app_module, "initialize_session", return_value=mock_agent), \
+         patch.object(app_module.db, "get_generation_status", return_value=_needs_input_row()), \
+         patch.object(app_module.db, "set_generation_status"), \
+         patch.object(app_module.db, "get_user_by_id", return_value={"username": "nu", "preferences": {}}), \
+         patch("spend_budget.get_spend_budget_usd", return_value=2.5), \
+         patch.object(app_module.threading, "Thread", return_value=mock_thread):
+        with api_client.session_transaction() as sess:
+            sess["user_id"] = "u1"
+        resp = api_client.post(
+            "/api/reports/answer",
+            json={"session_id": "sid-cli", "answers": ["Long-term"]},
+        )
+
+    assert resp.status_code == 200
+    assert resp.get_json()["success"] is True
+    assert mock_agent.current_ticker == "AAPL"
+    assert mock_agent.current_trade_type == "Investment"
+    assert mock_agent.user_id == "u1"
+    assert mock_agent.username == "nu"
+    mock_thread.start.assert_called_once()
+
+
+def test_answer_keeps_primed_agent_when_same_worker(api_client):
+    """Same-worker case: the agent already has its ticker -- do not overwrite."""
+    import app as app_module
+
+    mock_agent = MagicMock()
+    mock_agent.current_ticker = "AAPL"
+    mock_agent.current_trade_type = "Investment"
+    mock_agent.user_id = "u1"
+    mock_agent.username = "nu"
+    mock_thread = MagicMock()
+
+    row = _needs_input_row(ticker="MSFT", trade_type="Swing")
+
+    with patch.object(app_module, "initialize_session", return_value=mock_agent), \
+         patch.object(app_module.db, "get_generation_status", return_value=row), \
+         patch.object(app_module.db, "set_generation_status"), \
+         patch.object(app_module.db, "get_user_by_id", return_value={"username": "nu", "preferences": {}}), \
+         patch("spend_budget.get_spend_budget_usd", return_value=2.5), \
+         patch.object(app_module.threading, "Thread", return_value=mock_thread):
+        with api_client.session_transaction() as sess:
+            sess["user_id"] = "u1"
+        resp = api_client.post(
+            "/api/reports/answer",
+            json={"session_id": "sid-cli", "answers": ["Long-term"]},
+        )
+
+    assert resp.status_code == 200
+    assert mock_agent.current_ticker == "AAPL"
+    mock_thread.start.assert_called_once()
+
+
+def test_answer_400_when_ticker_unrecoverable(api_client):
+    """Legacy row without ticker + fresh agent: fail loudly with 400 instead of
+    running a blank agent that reports a fake upstream-sources error (#165)."""
+    import app as app_module
+
+    mock_agent = MagicMock()
+    mock_agent.current_ticker = None
+    mock_agent.current_trade_type = None
+    mock_thread = MagicMock()
+
+    row = _needs_input_row(ticker=None, trade_type=None)
+
+    with patch.object(app_module, "initialize_session", return_value=mock_agent), \
+         patch.object(app_module.db, "get_generation_status", return_value=row), \
+         patch.object(app_module.db, "set_generation_status"), \
+         patch.object(app_module.threading, "Thread", return_value=mock_thread):
+        with api_client.session_transaction() as sess:
+            sess["user_id"] = "u1"
+        resp = api_client.post(
+            "/api/reports/answer",
+            json={"session_id": "sid-cli", "answers": ["Long-term"]},
+        )
+
+    assert resp.status_code == 400
+    assert "error" in resp.get_json()
+    mock_thread.start.assert_not_called()
+
+
+def test_report_status_hides_ticker_fields(api_client):
+    """The status API response must not change shape: ticker/trade_type are
+    internal re-priming state, not part of the public payload."""
+    import app as app_module
+
+    row = _needs_input_row(status="in_progress", progress=5, step="Starting...")
+
+    with patch.object(app_module.db, "get_generation_status", return_value=row):
+        with api_client.session_transaction() as sess:
+            sess["user_id"] = "u1"
+        resp = api_client.get("/api/report_status/sid-cli")
+
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert "ticker" not in data
+    assert "trade_type" not in data
+    assert data["status"] == "in_progress"


### PR DESCRIPTION
Fixes #165

## Problem
CLI report generation failed most of the time with a fake "upstream data sources are down" error. The flow splits across `POST /api/reports/generate` (primes the agent in one gunicorn worker's in-memory `agent_sessions`) and `POST /api/reports/answer` (starts generation). When `answer` landed on a different worker, it silently got a blank agent with no ticker; `generate_report` returned "Error: No active research session." as a string, no report was produced, and the status handler wrote the misleading upstream-sources message. Confirmed on prod Railway logs 2026-07-05: generate on pid 6, answer on pid 4, zero research pipeline logs.

Same bug class as #116. The #117 fix restored state from the Flask session cookie, which CLI Bearer-auth requests do not carry.

## Fix
- Persist `ticker`/`trade_type` in the `generation_status` row (already cross-worker shared) at generate time. New columns are added via the standard idempotent `ALTER TABLE` migration in `init_schema`, which runs on deploy.
- In `api_reports_answer`, re-prime a fresh agent from the row: ticker, trade_type, user_id, username, language.
- Fail loudly with 400 when the ticker cannot be recovered, instead of running a blank agent.
- `/api/report_status` response shape is unchanged: the new columns are stripped from the payload.

## Tests
New `tests/test_reports_cli_flow.py` (5 tests): generate persists ticker, answer re-primes a fresh agent, same-worker agent is not overwritten, unrecoverable ticker returns 400, status API hides the new fields. All pass; also ran `test_flask_research_ajax.py`, `test_flask_api_routes.py`, `test_report_isolation.py`, `test_report_usage.py` — one pre-existing failure (`TestPositionCheckApi::test_returns_empty_when_no_holdings`) fails identically on clean main and is unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)